### PR TITLE
feat: Implement initial UI structure for Agent Creation page

### DIFF
--- a/client/src/components/agents/AgentConfigurator.tsx
+++ b/client/src/components/agents/AgentConfigurator.tsx
@@ -3,28 +3,22 @@ import React from 'react';
 // For now, let's use a placeholder div if Card is not found by the linter.
 // import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'; // Example import
 
-const AgentList: React.FC = () => {
+const AgentConfigurator: React.FC = () => {
   return (
     // Replace div with <Card className="h-full">
     <div>
       {/* Replace div with <CardHeader> */}
       <div>
         {/* Replace div with <CardTitle> */}
-        <div style={{ fontWeight: 'bold', fontSize: '1.25rem', marginBottom: '1rem' }}>Agents</div>
+        <div style={{ fontWeight: 'bold', fontSize: '1.25rem', marginBottom: '1rem' }}>Agent Configuration</div>
       </div>
       {/* Replace div with <CardContent> */}
       <div>
-        <p>List of created agents will appear here.</p>
-        {/* Example of how an agent might be listed - to be implemented later */}
-        {/*
-        <ul>
-          <li>Agent 1</li>
-          <li>Agent 2</li>
-        </ul>
-        */}
+        <p>Configuration form for the selected/new agent will appear here.</p>
+        {/* Form elements will be added in later steps */}
       </div>
     </div>
   );
 };
 
-export default AgentList;
+export default AgentConfigurator;

--- a/client/src/components/agents/AgentWorkspace.tsx
+++ b/client/src/components/agents/AgentWorkspace.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import AgentConfigurator from '@/components/agents/AgentConfigurator'; // Assuming '@/' path alias
+
+const AgentWorkspace: React.FC = () => {
+  return (
+    <div>
+      {/* <h2>Agent Workspace</h2> */}
+      <AgentConfigurator />
+    </div>
+  );
+};
+
+export default AgentWorkspace;

--- a/client/src/pages/Agentes.tsx
+++ b/client/src/pages/Agentes.tsx
@@ -1,9 +1,31 @@
-// src/pages/Agentes.tsx
-export default function AgentesPage() {
+import React from 'react';
+import AgentList from '@/components/agents/AgentList'; // Assuming '@/' is configured for src path
+import AgentWorkspace from '@/components/agents/AgentWorkspace';
+// Assuming shadcn/ui components are available.
+// If not, these imports would need to be adjusted or components created.
+// For now, let's use placeholder divs if Card is not found by the linter.
+// import { Card } from '@/components/ui/card'; // Example import for shadcn/ui Card
+
+const AgentesPage: React.FC = () => {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-semibold">Página de Agentes</h1>
-      <p>Conteúdo da página de Agentes.</p>
+    <div style={{ display: 'flex', height: '100vh', padding: '20px', boxSizing: 'border-box' }}>
+      {/* Left Column: AgentList */}
+      <div style={{ flex: '0 0 300px', marginRight: '20px' }}>
+        {/* Replace div with <Card className="h-full"> once shadcn is confirmed */}
+        <div style={{ border: '1px solid #e0e0e0', borderRadius: '8px', height: '100%', padding: '16px' }}>
+          <AgentList />
+        </div>
+      </div>
+
+      {/* Right Column: AgentWorkspace */}
+      <div style={{ flex: '1' }}>
+        {/* Replace div with <Card className="h-full"> once shadcn is confirmed */}
+        <div style={{ border: '1px solid #e0e0e0', borderRadius: '8px', height: '100%', padding: '16px' }}>
+          <AgentWorkspace />
+        </div>
+      </div>
     </div>
   );
-}
+};
+
+export default AgentesPage;

--- a/client/src/types/agent.ts
+++ b/client/src/types/agent.ts
@@ -1,0 +1,66 @@
+// Base interface for all agent configurations
+export interface AgentConfig {
+  id: string; // Unique identifier for the agent
+  name: string; // Display name for the agent
+  type: AgentType; // Type of the agent
+}
+
+// Enum for different agent types
+export enum AgentType {
+  LLM = 'LlmAgent',
+  Sequential = 'SequentialAgent',
+  Parallel = 'ParallelAgent',
+  Loop = 'LoopAgent',
+  // Add other agent types as needed
+}
+
+// Interface for LLM Agent configuration
+export interface LlmAgentConfig extends AgentConfig {
+  type: AgentType.LLM;
+  instruction: string;
+  model: string;
+  // Add other LLM-specific parameters here, e.g., temperature, top_p
+}
+
+// Interface for Sequential Agent configuration
+export interface SequentialAgentConfig extends AgentConfig {
+  type: AgentType.Sequential;
+  agents: AgentConfig[]; // List of agents to run in sequence
+}
+
+// Interface for Parallel Agent configuration
+export interface ParallelAgentConfig extends AgentConfig {
+  type: AgentType.Parallel;
+  agents: AgentConfig[]; // List of agents to run in parallel
+}
+
+// Interface for Loop Agent configuration
+export interface LoopAgentConfig extends AgentConfig {
+  type: AgentType.Loop;
+  agent: AgentConfig; // The agent to run in a loop
+  max_iterations?: number; // Optional maximum number of iterations
+}
+
+// Union type for any agent configuration
+export type AnyAgentConfig = LlmAgentConfig | SequentialAgentConfig | ParallelAgentConfig | LoopAgentConfig;
+
+// Interface for a tool that can be used by an agent
+export interface Tool {
+  id: string;
+  name: string;
+  description: string;
+  // Parameters specific to the tool, if any
+  // Example: parameters: { [key: string]: any };
+}
+
+// Interface for an agent definition that might include tools
+export interface AgentWithToolsConfig extends AgentConfig {
+  tools?: Tool[]; // Optional list of tools
+  // mcp_tools?: any[]; // Placeholder for MCP Tools if they have a different structure
+}
+
+// Example of extending LlmAgentConfig to include tools
+export interface LlmAgentWithToolsConfig extends LlmAgentConfig, AgentWithToolsConfig {}
+
+// You might want to create more specific types like these as you flesh out the application:
+// export type AnyAgentWithToolsConfig = LlmAgentWithToolsConfig | ... ;


### PR DESCRIPTION
I've created the foundational directory structure and files for the agent creation interface as per the first step of our plan.

This includes:
- Directories: client/src/pages, client/src/components/agents, client/src/types
- Page component: client/src/pages/Agentes.tsx with a two-column layout.
- Base components:
    - client/src/components/agents/AgentWorkspace.tsx
    - client/src/components/agents/AgentList.tsx
    - client/src/components/agents/AgentConfigurator.tsx
- TypeScript types: client/src/types/agent.ts with initial interfaces for agent configurations (LlmAgent, SequentialAgent, etc.).

The created components currently have placeholder content. Routing for the new page is pending and will be addressed next.