### PR TITLE
feat: Interface de Agentes (Etapas 1-2 Concluídas, Etapa 3 Tarefa 5/7)

### DIFF
--- a/client/src/components/agents/AgentConfigurator.tsx
+++ b/client/src/components/agents/AgentConfigurator.tsx
@@ -1,9 +1,134 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { LlmAgentConfig, AgentType, AnyAgentConfig, SequentialAgentConfig, ParallelAgentConfig } from '@/types/agent';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { ToolSelector } from '@/components/agents/tools';
+import { Badge } from "@/components/ui/badge";
+import { XIcon } from 'lucide-react'; // Ou use um 'x' textual se lucide-react não estiver disponível
+import mockToolsData from '../../../data/mock-tools.json'; // Ajuste o caminho se necessário
+import { AgentDropzone } from '@/components/agents/workflow';
+import AgentList from '@/components/agents/AgentList';
+
 // Assuming shadcn/ui components are available.
 // For now, let's use a placeholder div if Card is not found by the linter.
 // import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'; // Example import
 
-const AgentConfigurator: React.FC = () => {
+interface AgentConfiguratorProps {
+  agentConfig: AnyAgentConfig; // Changed to AnyAgentConfig
+  onConfigChange: (newConfig: AnyAgentConfig) => void; // Changed to AnyAgentConfig
+}
+
+const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({ agentConfig, onConfigChange }) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    onConfigChange({
+      ...agentConfig,
+      [name]: value,
+    });
+  };
+
+  // Renamed from handleSelectChange to handleTypeChange for clarity
+  const handleTypeChange = (newTypeString: string) => {
+    const newType = newTypeString as AgentType;
+    const baseConfig = {
+      id: agentConfig.id, // Preserve ID
+      name: agentConfig.name, // Preserve Name
+      type: newType,
+    };
+
+    if (newType === AgentType.LLM) {
+      onConfigChange({
+        ...baseConfig,
+        instruction: (agentConfig as LlmAgentConfig).instruction || '', // Retain if possible, else default
+        model: (agentConfig as LlmAgentConfig).model || 'gpt-3.5-turbo', // Retain if possible, else default
+        code_execution: (agentConfig as LlmAgentConfig).code_execution || false,
+        planning_enabled: (agentConfig as LlmAgentConfig).planning_enabled || false,
+        tools: (agentConfig as LlmAgentConfig).tools || [],
+      } as LlmAgentConfig);
+    } else if (newType === AgentType.Sequential || newType === AgentType.Parallel) {
+      let newSpecificConfig: SequentialAgentConfig | ParallelAgentConfig;
+      if (newType === AgentType.Sequential) {
+        newSpecificConfig = {
+          ...baseConfig,
+          type: AgentType.Sequential,
+          agents: (agentConfig as SequentialAgentConfig).agents || [], // Retain if possible, else default
+        };
+      } else { // AgentType.Parallel
+        newSpecificConfig = {
+          ...baseConfig,
+          type: AgentType.Parallel,
+          agents: (agentConfig as ParallelAgentConfig).agents || [], // Retain if possible, else default
+        };
+      }
+      onConfigChange(newSpecificConfig);
+    } else {
+      // For other types or if no specific fields are needed initially beyond base
+      onConfigChange(baseConfig);
+    }
+  };
+
+  const handleSwitchChange = (checked: boolean, name: keyof LlmAgentConfig) => {
+    // This function is specific to LlmAgentConfig, ensure it's only called when type is LLM
+    if (agentConfig.type === AgentType.LLM) {
+      onConfigChange({
+        ...agentConfig,
+        [name]: checked,
+      } as LlmAgentConfig); // Cast to LlmAgentConfig
+    }
+  };
+
+  const handleSave = () => {
+    console.log('Salvando agente:', agentConfig);
+    console.log(JSON.stringify(agentConfig, null, 2));
+    // Aqui você adicionaria a lógica para realmente salvar o agente,
+    // por exemplo, chamando uma API ou uma função passada por props.
+  };
+
+  const handleRemoveTool = (toolIdToRemove: string) => {
+    const updatedTools = agentConfig.tools?.filter(id => id !== toolIdToRemove);
+    onConfigChange({ ...agentConfig, tools: updatedTools });
+  };
+
+  const isSaveDisabled = !agentConfig || !agentConfig.name || agentConfig.name.trim() === '' ||
+                         (agentConfig.type === AgentType.LLM && !(agentConfig as LlmAgentConfig).instruction?.trim());
+  const [isToolSelectorOpen, setIsToolSelectorOpen] = useState(false);
+  const [isAddSubAgentModalOpen, setIsAddSubAgentModalOpen] = useState(false);
+  const [selectedAgentIdsForModal, setSelectedAgentIdsForModal] = useState<string[]>([]);
+
+  // Helper to safely access LLM specific props
+  const llmConfig = agentConfig.type === AgentType.LLM ? agentConfig as LlmAgentConfig : null;
+
+  const mockExistingAgents: AnyAgentConfig[] = [
+    { id: 'agent_1', name: 'Agente de Pesquisa Web', type: AgentType.LLM, instruction: 'Pesquise na web', model: 'gpt-3.5-turbo' },
+    { id: 'agent_2', name: 'Agente Escritor de Artigos', type: AgentType.LLM, instruction: 'Escreva um artigo', model: 'gpt-4' },
+    { id: 'agent_3', name: 'Agente Tradutor', type: AgentType.LLM, instruction: 'Traduza o texto', model: 'gpt-3.5-turbo', tools: ['calculator'] },
+  ];
+
   return (
     // Replace div with <Card className="h-full">
     <div>
@@ -14,8 +139,239 @@ const AgentConfigurator: React.FC = () => {
       </div>
       {/* Replace div with <CardContent> */}
       <div>
-        <p>Configuration form for the selected/new agent will appear here.</p>
-        {/* Form elements will be added in later steps */}
+        {/* Campos Comuns */}
+        <div style={{ marginBottom: '1rem' }}>
+          <Label htmlFor="agentName">Nome do Agente</Label>
+          <Input
+            id="agentName"
+            name="name"
+            value={agentConfig.name || ''}
+            onChange={handleInputChange}
+            placeholder="Ex: Agente de Pesquisa"
+          />
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <Label htmlFor="agentType">Tipo de Agente</Label>
+          <Select
+            value={agentConfig.type}
+            onValueChange={handleTypeChange} // Changed to handleTypeChange
+          >
+            <SelectTrigger id="agentType">
+              <SelectValue placeholder="Selecione o tipo" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={AgentType.LLM}>LLM Agent</SelectItem>
+              <SelectItem value={AgentType.Sequential}>Sequential Agent</SelectItem>
+              <SelectItem value={AgentType.Parallel}>Parallel Agent</SelectItem>
+              {/* Adicione AgentType.Loop aqui se necessário */}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Campos Específicos do Tipo de Agente */}
+        {agentConfig.type === AgentType.LLM && llmConfig && (
+          <>
+            <Accordion type="multiple" defaultValue={["item-1", "item-2"]} className="w-full mt-4">
+              <AccordionItem value="item-1">
+                <AccordionTrigger>Configuração Principal</AccordionTrigger>
+                <AccordionContent>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', paddingTop: '1rem' }}>
+                    <div style={{ marginBottom: '1rem' }}>
+                      <Label htmlFor="instruction">Instrução</Label>
+                      <Textarea
+                        id="instruction"
+                        name="instruction"
+                        value={llmConfig.instruction || ''}
+                        onChange={handleInputChange}
+                        placeholder="Instrução detalhada para o agente..."
+                        rows={4}
+                      />
+                    </div>
+                    <div style={{ marginBottom: '1rem' }}>
+                      <Label htmlFor="model">Modelo</Label>
+                      <Input
+                        id="model"
+                        name="model"
+                        value={llmConfig.model || ''}
+                        onChange={handleInputChange}
+                        placeholder="Ex: gpt-4, gemini-pro"
+                      />
+                    </div>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="item-2">
+                <AccordionTrigger>Parâmetros Avançados</AccordionTrigger>
+                <AccordionContent>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', paddingTop: '1rem' }}>
+                    <div style={{ marginBottom: '1rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                      <Label htmlFor="codeExecutionSwitch" style={{ marginRight: '1rem' }}>Execução de Código</Label>
+                      <Switch
+                        id="codeExecutionSwitch"
+                        checked={llmConfig.code_execution || false}
+                        onCheckedChange={(checked) => handleSwitchChange(checked, 'code_execution')}
+                      />
+                    </div>
+                    <div style={{ marginBottom: '1rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                      <Label htmlFor="planningEnabledSwitch" style={{ marginRight: '1rem' }}>Planejamento Habilitado</Label>
+                      <Switch
+                        id="planningEnabledSwitch"
+                        checked={llmConfig.planning_enabled || false}
+                        onCheckedChange={(checked) => handleSwitchChange(checked, 'planning_enabled')}
+                      />
+                    </div>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+
+            <Dialog open={isToolSelectorOpen} onOpenChange={setIsToolSelectorOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" style={{ marginTop: '20px', marginRight: '10px' }}>
+                  Adicionar Ferramenta
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-[425px]">
+                <DialogHeader>
+                  <DialogTitle>Selecionar Ferramentas</DialogTitle>
+                </DialogHeader>
+                <ToolSelector
+                  selectedTools={llmConfig.tools || []}
+                  onSelectionChange={(selectedIds) => {
+                    onConfigChange({ ...llmConfig, tools: selectedIds } as LlmAgentConfig);
+                  }}
+                />
+                <DialogFooter>
+                  <DialogClose asChild>
+                    <Button type="button">Confirmar</Button>
+                  </DialogClose>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+
+            {llmConfig.tools && llmConfig.tools.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-4 mb-4">
+                {llmConfig.tools.map((toolId) => {
+                  const tool = mockToolsData.find(t => t.id === toolId);
+                  return (
+                    <Badge key={toolId} variant="secondary" className="flex items-center gap-1">
+                      {tool ? tool.name : toolId}
+                      <button
+                        onClick={() => handleRemoveTool(toolId)}
+                        className="ml-1 rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        aria-label={`Remover ${tool ? tool.name : toolId}`}
+                      >
+                        <XIcon className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                      </button>
+                    </Badge>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+
+        {agentConfig.type === AgentType.Sequential && (
+          <div className="mt-4">
+            <h3 className="text-xl font-semibold mb-2">Configuração do Agente Sequencial</h3>
+            <AgentDropzone subAgents={(agentConfig as SequentialAgentConfig).agents || []} />
+            <div className="mt-4">
+              <Dialog open={isAddSubAgentModalOpen} onOpenChange={setIsAddSubAgentModalOpen}>
+                <DialogTrigger asChild>
+                  <Button variant="outline" onClick={() => {
+                    setSelectedAgentIdsForModal([]);
+                    setIsAddSubAgentModalOpen(true);
+                  }}>
+                    Adicionar Sub-Agente
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="sm:max-w-[600px]">
+                  <DialogHeader>
+                    <DialogTitle>Adicionar Sub-Agente ao Workflow</DialogTitle>
+                  </DialogHeader>
+                  <AgentList
+                    agents={mockExistingAgents.filter(agent => agent.id !== agentConfig.id)}
+                    selectedAgentIds={selectedAgentIdsForModal}
+                    onAgentToggle={(agentId) => {
+                      setSelectedAgentIdsForModal(prev =>
+                        prev.includes(agentId) ? prev.filter(id => id !== agentId) : [...prev, agentId]
+                      );
+                    }}
+                    selectable={true}
+                    title="Selecione os Agentes"
+                  />
+                  <DialogFooter>
+                    <Button type="button" variant="ghost" onClick={() => setIsAddSubAgentModalOpen(false)}>Cancelar</Button>
+                    <Button type="button" onClick={() => {
+                      console.log("IDs dos sub-agentes selecionados:", selectedAgentIdsForModal);
+                      setIsAddSubAgentModalOpen(false);
+                    }}>
+                      Adicionar Selecionados
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </div>
+          </div>
+        )}
+
+        {agentConfig.type === AgentType.Parallel && (
+          <div className="mt-4">
+            <h3 className="text-xl font-semibold mb-2">Configuração do Agente Paralelo</h3>
+            <AgentDropzone subAgents={(agentConfig as ParallelAgentConfig).agents || []} />
+            <div className="mt-4">
+              <Dialog open={isAddSubAgentModalOpen} onOpenChange={setIsAddSubAgentModalOpen}>
+                <DialogTrigger asChild>
+                  <Button variant="outline" onClick={() => {
+                    setSelectedAgentIdsForModal([]);
+                    setIsAddSubAgentModalOpen(true);
+                  }}>
+                    Adicionar Sub-Agente
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="sm:max-w-[600px]">
+                  <DialogHeader>
+                    <DialogTitle>Adicionar Sub-Agente ao Workflow</DialogTitle>
+                  </DialogHeader>
+                  <AgentList
+                    agents={mockExistingAgents.filter(agent => agent.id !== agentConfig.id)}
+                    selectedAgentIds={selectedAgentIdsForModal}
+                    onAgentToggle={(agentId) => {
+                      setSelectedAgentIdsForModal(prev =>
+                        prev.includes(agentId) ? prev.filter(id => id !== agentId) : [...prev, agentId]
+                      );
+                    }}
+                    selectable={true}
+                    title="Selecione os Agentes"
+                  />
+                  <DialogFooter>
+                    <Button type="button" variant="ghost" onClick={() => setIsAddSubAgentModalOpen(false)}>Cancelar</Button>
+                    <Button type="button" onClick={() => {
+                      console.log("IDs dos sub-agentes selecionados:", selectedAgentIdsForModal);
+                      setIsAddSubAgentModalOpen(false);
+                    }}>
+                      Adicionar Selecionados
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </div>
+          </div>
+        )}
+
+        {/* Fallback para tipos não reconhecidos (opcional) */}
+        {![AgentType.LLM, AgentType.Sequential, AgentType.Parallel].includes(agentConfig.type) && (
+           <p className="mt-4">Tipo de agente não reconhecido ou configuração não disponível.</p>
+        )}
+
+        <Button
+          onClick={handleSave}
+          disabled={isSaveDisabled}
+          style={{ marginTop: '20px' }}
+        >
+          Salvar Agente
+        </Button>
       </div>
     </div>
   );

--- a/client/src/components/agents/AgentList.tsx
+++ b/client/src/components/agents/AgentList.tsx
@@ -1,29 +1,60 @@
 import React from 'react';
-// Assuming shadcn/ui components are available.
-// For now, let's use a placeholder div if Card is not found by the linter.
-// import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'; // Example import
+import { AnyAgentConfig } from '@/types/agent'; // Ajuste o caminho
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
-const AgentList: React.FC = () => {
+interface AgentListProps {
+  agents: AnyAgentConfig[];
+  selectedAgentIds?: string[]; // IDs dos agentes já selecionados/marcados
+  onAgentToggle?: (agentId: string) => void; // Função para marcar/desmarcar
+  title?: string; // Título opcional para o card
+  selectable?: boolean; // Indica se os checkboxes devem ser mostrados
+}
+
+const AgentList: React.FC<AgentListProps> = ({
+  agents,
+  selectedAgentIds = [],
+  onAgentToggle,
+  title = "Agentes Disponíveis",
+  selectable = false,
+}) => {
   return (
-    // Replace div with <Card className="h-full">
-    <div>
-      {/* Replace div with <CardHeader> */}
-      <div>
-        {/* Replace div with <CardTitle> */}
-        <div style={{ fontWeight: 'bold', fontSize: '1.25rem', marginBottom: '1rem' }}>Agents</div>
-      </div>
-      {/* Replace div with <CardContent> */}
-      <div>
-        <p>List of created agents will appear here.</p>
-        {/* Example of how an agent might be listed - to be implemented later */}
-        {/*
-        <ul>
-          <li>Agent 1</li>
-          <li>Agent 2</li>
-        </ul>
-        */}
-      </div>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {agents.length === 0 && <p className="text-sm text-muted-foreground">Nenhum agente encontrado.</p>}
+        <div className="space-y-3">
+          {agents.map((agent) => (
+            <div
+              key={agent.id}
+              className={`flex items-center p-3 rounded-md border ${
+                selectable && onAgentToggle ? 'cursor-pointer hover:bg-accent' : ''
+              } ${selectedAgentIds.includes(agent.id) ? 'bg-accent' : ''}`}
+              onClick={() => selectable && onAgentToggle && onAgentToggle(agent.id)}
+            >
+              {selectable && onAgentToggle && (
+                <Checkbox
+                  id={`agent-select-${agent.id}`}
+                  checked={selectedAgentIds.includes(agent.id)}
+                  onCheckedChange={() => onAgentToggle(agent.id)} // onCheckedChange espera um boolean ou 'indeterminate'
+                  className="mr-3"
+                  aria-labelledby={`agent-label-${agent.id}`}
+                />
+              )}
+              <div className="flex-1">
+                <Label htmlFor={selectable && onAgentToggle ? `agent-select-${agent.id}` : undefined} id={`agent-label-${agent.id}`} className="font-medium">
+                  {agent.name || `Agente ${agent.id.substring(0, 6)}`}
+                </Label>
+                <p className="text-xs text-muted-foreground">{agent.type}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/client/src/components/agents/AgentWorkspace.tsx
+++ b/client/src/components/agents/AgentWorkspace.tsx
@@ -1,11 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { LlmAgentConfig, AgentType, AnyAgentConfig } from '@/types/agent'; // Assuming '@/' path alias
 import AgentConfigurator from '@/components/agents/AgentConfigurator'; // Assuming '@/' path alias
+import JsonPreview from './JsonPreview';
 
 const AgentWorkspace: React.FC = () => {
+  const initialLlmConfig: LlmAgentConfig = {
+    id: crypto.randomUUID(),
+    name: '',
+    type: AgentType.LLM,
+    instruction: '',
+    model: 'gpt-3.5-turbo',
+    code_execution: false,
+    planning_enabled: false,
+    tools: [],
+  };
+  const [agentConfig, setAgentConfig] = useState<AnyAgentConfig>(initialLlmConfig);
+
   return (
-    <div>
-      {/* <h2>Agent Workspace</h2> */}
-      <AgentConfigurator />
+    <div style={{ display: 'flex', gap: '20px', padding: '20px' }}>
+      <div style={{ flex: 1 }}>
+        {/* <h2>Agent Workspace</h2> */}
+        <AgentConfigurator agentConfig={agentConfig} onConfigChange={setAgentConfig} />
+      </div>
+      <div style={{ flex: 1 }}>
+        <JsonPreview data={agentConfig} />
+      </div>
     </div>
   );
 };

--- a/client/src/components/agents/JsonPreview.tsx
+++ b/client/src/components/agents/JsonPreview.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface JsonPreviewProps {
+  data: any;
+}
+
+const JsonPreview: React.FC<JsonPreviewProps> = ({ data }) => {
+  return (
+    <div style={{ marginTop: '20px' }}>
+      <h3 style={{ marginBottom: '10px' }}>Configuração JSON em Tempo Real</h3>
+      <pre style={{
+        background: '#f4f4f4',
+        border: '1px solid #ddd',
+        padding: '10px',
+        borderRadius: '4px',
+        whiteSpace: 'pre-wrap', // Garante a quebra de linha
+        wordWrap: 'break-word' // Garante que palavras longas não quebrem o layout
+      }}>
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  );
+};
+
+export default JsonPreview;

--- a/client/src/components/agents/tools/ToolSelector.tsx
+++ b/client/src/components/agents/tools/ToolSelector.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import mockToolsData from '../../../data/mock-tools.json'; // Ajuste o caminho se necessário
+
+// Importe aqui os componentes do shadcn/ui que serão usados no futuro
+// Ex: import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+// Ex: import { Button } from "@/components/ui/button";
+
+interface Tool {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface ToolSelectorProps {
+  selectedTools: string[]; // IDs das ferramentas já selecionadas
+  onSelectionChange: (selectedIds: string[]) => void; // Função para atualizar as ferramentas selecionadas
+  // open: boolean; // Controlará a visibilidade do Dialog
+  // onOpenChange: (open: boolean) => void; // Para fechar o Dialog
+}
+
+const ToolSelector: React.FC<ToolSelectorProps> = ({
+  selectedTools,
+  onSelectionChange,
+  // open,
+  // onOpenChange
+}) => {
+  const [loadedTools, setLoadedTools] = useState<Tool[]>([]);
+
+  useEffect(() => {
+    // Simula o carregamento, em um cenário real seria uma chamada API
+    setLoadedTools(mockToolsData);
+  }, []);
+
+  return (
+    <div className="grid gap-4 py-4">
+      {loadedTools.map((tool) => (
+        <div key={tool.id} className="flex items-center space-x-3">
+          <Checkbox
+            id={tool.id}
+            checked={selectedTools.includes(tool.id)}
+            onCheckedChange={(checked) => {
+              const newSelectedIds = typeof checked === 'boolean' && checked
+                ? [...selectedTools, tool.id]
+                : selectedTools.filter((id) => id !== tool.id);
+              onSelectionChange(newSelectedIds);
+            }}
+          />
+          <div className="grid gap-1.5 leading-none">
+            <Label
+              htmlFor={tool.id}
+              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            >
+              {tool.name}
+            </Label>
+            {tool.description && (
+              <p className="text-xs text-muted-foreground">
+                {tool.description}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ToolSelector;

--- a/client/src/components/agents/tools/index.ts
+++ b/client/src/components/agents/tools/index.ts
@@ -1,0 +1,1 @@
+export * from './ToolSelector';

--- a/client/src/components/agents/workflow/AgentDropzone.tsx
+++ b/client/src/components/agents/workflow/AgentDropzone.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { AnyAgentConfig } from '@/types/agent'; // Ajuste o caminho se necessário
+import SubAgentCard from './SubAgentCard';
+
+interface AgentDropzoneProps {
+  subAgents: AnyAgentConfig[];
+  onRemoveSubAgent?: (agentId: string) => void; // Adicionando prop para remover
+  // onSubAgentsChange: (newSubAgents: AnyAgentConfig[]) => void; // Será usado depois
+  // readOnly?: boolean; // Para visualização vs edição
+  // parentAgentType?: AgentType.Sequential | AgentType.Parallel; // Para lógica condicional D&D
+}
+
+const AgentDropzone: React.FC<AgentDropzoneProps> = ({
+  subAgents,
+  onRemoveSubAgent,
+  // onSubAgentsChange,
+}) => {
+  return (
+    <div className="mt-4 p-4 border-2 border-dashed border-gray-300 rounded-lg min-h-[200px] bg-gray-50">
+      <h4 className="text-lg font-semibold text-gray-700 mb-3">
+        Sub-Agentes do Workflow
+      </h4>
+      {subAgents.length === 0 && (
+        <div className="text-center text-gray-500">
+          <p>Arraste e solte agentes aqui ou adicione usando o botão abaixo.</p>
+          <p>(Funcionalidade de Drag & Drop e botão "Adicionar" serão implementados em breve)</p>
+        </div>
+      )}
+      <div className="space-y-2 mt-4">
+        {subAgents.map((agentConfig, idx) => (
+          <SubAgentCard
+            key={agentConfig.id || idx}
+            agent={agentConfig}
+            index={idx}
+            onRemove={onRemoveSubAgent ? () => onRemoveSubAgent(agentConfig.id) : undefined}
+            // onMove={() => {}} // Passar um handler real depois
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AgentDropzone;

--- a/client/src/components/agents/workflow/SubAgentCard.tsx
+++ b/client/src/components/agents/workflow/SubAgentCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { AnyAgentConfig, AgentType } from '@/types/agent'; // Ajuste o caminho se necessário
+import { Card, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card'; // Shadcn card
+import { Button } from '@/components/ui/button';
+import { GripVerticalIcon, Trash2Icon } from 'lucide-react'; // Para D&D e remoção
+
+interface SubAgentCardProps {
+  agent: AnyAgentConfig;
+  index: number; // Para futuras implementações de D&D e key
+  // onMove?: (dragIndex: number, hoverIndex: number) => void; // Para D&D
+  onRemove?: (agentId: string) => void; // Para remover o sub-agente
+  // readOnly?: boolean;
+}
+
+const SubAgentCard: React.FC<SubAgentCardProps> = ({
+  agent,
+  index,
+  onRemove,
+}) => {
+  const handleRemove = () => {
+    if (onRemove) {
+      onRemove(agent.id);
+    } else {
+      console.log("Remover (não implementado):", agent.id);
+    }
+  };
+
+  // Simples mapeamento de tipo para um ícone ou cor (pode ser expandido)
+  const getAgentTypeDetails = (type: AgentType) => {
+    switch (type) {
+      case AgentType.LLM:
+        return { icon: '🤖', color: 'bg-blue-100', label: 'LLM Agent' };
+      case AgentType.Sequential:
+        return { icon: '→', color: 'bg-green-100', label: 'Sequential' }; // Ícone de seta
+      case AgentType.Parallel:
+        return { icon: '||', color: 'bg-yellow-100', label: 'Parallel' }; // Ícone de paralelo
+      default:
+        return { icon: '⚙️', color: 'bg-gray-100', label: type };
+    }
+  };
+
+  const typeDetails = getAgentTypeDetails(agent.type);
+
+  return (
+    <Card className={`mb-3 shadow-md hover:shadow-lg transition-shadow duration-200 ${typeDetails.color}`}>
+      <CardHeader className="p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <GripVerticalIcon className="h-5 w-5 text-gray-400 cursor-grab" /> {/* Handle para D&D */}
+            <div>
+              <CardTitle className="text-base font-semibold">{agent.name || `Sub-Agente ${index + 1}`}</CardTitle>
+              <CardDescription className="text-xs">{typeDetails.label}</CardDescription>
+            </div>
+          </div>
+          {onRemove && (
+            <Button variant="ghost" size="icon" onClick={handleRemove} aria-label="Remover sub-agente">
+              <Trash2Icon className="h-4 w-4 text-red-500 hover:text-red-700" />
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      {/* Poderíamos adicionar CardContent ou CardFooter se precisarmos de mais detalhes no futuro */}
+    </Card>
+  );
+};
+
+export default SubAgentCard;

--- a/client/src/components/agents/workflow/index.ts
+++ b/client/src/components/agents/workflow/index.ts
@@ -1,0 +1,2 @@
+export { default as AgentDropzone } from './AgentDropzone';
+export { default as SubAgentCard } from './SubAgentCard'; // Adicionar esta linha

--- a/client/src/data/mock-tools.json
+++ b/client/src/data/mock-tools.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "web_search",
+    "name": "Web Search",
+    "description": "Permite que o agente pesquise na web para obter informações atualizadas."
+  },
+  {
+    "id": "image_generator",
+    "name": "Image Generator",
+    "description": "Permite que o agente gere imagens com base em prompts de texto."
+  },
+  {
+    "id": "calculator",
+    "name": "Calculator",
+    "description": "Fornece ao agente a capacidade de realizar cálculos matemáticos."
+  },
+  {
+    "id": "code_interpreter",
+    "name": "Code Interpreter",
+    "description": "Permite que o agente execute código Python em um ambiente sandbox."
+  },
+  {
+    "id": "file_reader",
+    "name": "File Reader",
+    "description": "Permite que o agente leia o conteúdo de arquivos fornecidos."
+  }
+]

--- a/client/src/types/agent.ts
+++ b/client/src/types/agent.ts
@@ -19,26 +19,34 @@ export interface LlmAgentConfig extends AgentConfig {
   type: AgentType.LLM;
   instruction: string;
   model: string;
+  code_execution?: boolean;
+  planning_enabled?: boolean;
+  tools?: string[]; // <--- Adicionar esta linha
   // Add other LLM-specific parameters here, e.g., temperature, top_p
 }
 
 // Interface for Sequential Agent configuration
 export interface SequentialAgentConfig extends AgentConfig {
   type: AgentType.Sequential;
-  agents: AgentConfig[]; // List of agents to run in sequence
+  agents: AnyAgentConfig[]; // <--- Corrigido para AnyAgentConfig[]
 }
 
 // Interface for Parallel Agent configuration
 export interface ParallelAgentConfig extends AgentConfig {
   type: AgentType.Parallel;
-  agents: AgentConfig[]; // List of agents to run in parallel
+  agents: AnyAgentConfig[]; // <--- Corrigido para AnyAgentConfig[]
 }
 
 // Interface for Loop Agent configuration
 export interface LoopAgentConfig extends AgentConfig {
   type: AgentType.Loop;
-  agent: AgentConfig; // The agent to run in a loop
+  agent: AnyAgentConfig; // <--- Corrigido para AnyAgentConfig (um único agente, mas pode ser qualquer tipo)
   max_iterations?: number; // Optional maximum number of iterations
+}
+
+// Helper type for agents that contain other agents (workflows)
+export interface WorkflowAgentConfig extends AgentConfig {
+  agents: AnyAgentConfig[];
 }
 
 // Union type for any agent configuration


### PR DESCRIPTION
Este commit inclui o meu progresso nas três primeiras etapas do desenvolvimento da interface de criação e configuração de agentes.

Etapa 1: Implementação do Formulário do Agente Principal (LLM Agent) - Concluída
- Configurei o estado inicial para LlmAgentConfig, posteriormente generalizado para AnyAgentConfig no AgentWorkspace.
- Implementei os campos do formulário (Nome, Instrução, Modelo, Tipo de Agente) com componentes shadcn/ui.
- Adicionei Switches para code_execution e planning_enabled.
- Criei o JsonPreview para visualização da configuração.
- Agrupei campos com Accordion.
- Criei o botão 'Salvar Agente' (log no console) com validação básica.

Etapa 2: Integração da Biblioteca e Seleção de Ferramentas (Tools) - Concluída
- Criei o ToolSelector.tsx, carregando mock-tools.json.
- O botão 'Adicionar Ferramenta' no AgentConfigurator abre o ToolSelector em um Dialog.
- A seleção de ferramentas por checkboxes atualiza agentConfig.tools.
- As ferramentas selecionadas são exibidas como Badges removíveis.
- A interface LlmAgentConfig foi atualizada com o campo 'tools'.

Etapa 3: Construção da Interface para Agentes de Workflow - Tarefa 5 de 7 Concluída
- Ativei as opções SequentialAgent e ParallelAgent no seletor de tipo de agente.
- Implementei a renderização condicional no AgentConfigurator para diferentes tipos de agente, com limpeza/adaptação de campos ao mudar o tipo.
- Criei o AgentDropzone.tsx para exibir agentes.
- Criei o SubAgentCard.tsx para renderizar informações compactas de cada agente na AgentDropzone.
- Implementei um botão 'Adicionar Agente' que abre um modal.
- O modal exibe uma AgentList (com agentes mockados e checkboxes) para selecionar agentes. O estado dos agentes selecionados no modal é rastreado.

Próximos passos para a Etapa 3:
- Adicionar os agentes selecionados no modal ao estado do agente de workflow.
- Implementar drag-and-drop para reordenar agentes.