### PR TITLE
Fix AgentList tests with new checkbox component

### DIFF
--- a/client/src/components/agents/AgentList.test.tsx
+++ b/client/src/components/agents/AgentList.test.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import AgentList from './AgentList';
-import { useAgentStore } from '@/store/agentStore';
-import { AnyAgentConfig, AgentType } from '@/types/agent';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import AgentList from './AgentList'
+import { useAgentStore } from '@/store/agentStore'
+import { AnyAgentConfig, AgentType } from '@/types/agent'
 
 // Mock o useAgentStore
-jest.mock('@/store/agentStore');
+vi.mock('@/store/agentStore')
 
 const mockAgents: AnyAgentConfig[] = [
   {
@@ -36,13 +37,11 @@ const mockAgents: AnyAgentConfig[] = [
 
 describe('AgentList Component', () => {
   beforeEach(() => {
-    // Reseta o mock antes de cada teste
-    (useAgentStore as jest.Mock).mockReturnValue({
-      agents: mockAgents,
-      // Adicione outros estados/seletores do store que AgentList possa usar, se houver
-      // Por exemplo: activeAgent: null, setActiveAgent: jest.fn(), etc.
-    });
-  });
+    // Reseta o mock antes de cada teste retornando o estado solicitado
+    vi.mocked(useAgentStore).mockImplementation((selector: any) =>
+      selector({ agents: mockAgents })
+    )
+  })
 
   test('renders all agents when searchTerm is empty', () => {
     render(<AgentList title="Meus Agentes" />);

--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn(
+        'h-4 w-4 rounded border border-input text-primary focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Checkbox.displayName = 'Checkbox'
+
+export { Checkbox }

--- a/client/src/components/ui/index.ts
+++ b/client/src/components/ui/index.ts
@@ -21,5 +21,8 @@ export * from "./use-toast"
 // Accordion components
 export * from "./accordion";
 
+// Form controls
+export * from "./checkbox"
+
 // Hooks and Utilities
 export * from "@/lib/utils"


### PR DESCRIPTION
## Summary
- add missing `<Checkbox>` component used across the UI
- export the new component in `ui/index`
- update tests for `AgentList` to use Vitest mock helpers

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6844c7a324e8832eb8c52e8e2393c733