### PR TITLE
Add architecture overview and service hooks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,74 @@
+# Plataforma de Agentes - Arquitetura
+
+## Vis\u00e3o Geral
+Este documento descreve a organiza\u00e7\u00e3o do c\u00f3digo e as camadas da aplica\u00e7\u00e3o. O objetivo \u00e9 manter uma estrutura modular, previs\u00edvel e f\u00e1cil de manter.
+
+## Stack Tecnol\u00f3gica
+- **React** com **Vite**
+- **TypeScript**
+- **Zustand** para estado global
+- **Tailwind CSS** e **shadcn/ui** para a interface
+- **Vitest** e **Testing Library** para testes
+
+## Estrutura de Pastas
+```
+client/src
+|-- api/             # Configura\u00e7\u00f5es iniciais e cliente HTTP
+|-- components/
+|   |-- ui/          # Componentes visuais reutiliz\u00e1veis
+|   |-- layouts/     # Componentes de layout principal
+|   |-- features/    # Componentes agrupados por funcionalidade
+|   |-- agents/      # Funcionalidades espec\u00edficas de agentes
+|       |-- config_forms/
+|-- hooks/           # L\u00f3gica de UI e efeitos colaterais
+|-- services/        # Comunica\u00e7\u00e3o com APIs
+|-- store/           # Zustand stores
+|-- types/           # Tipagens de dom\u00ednio
+|-- pages/           # Entradas de rota
+|-- main.tsx         # Ponto de entrada
+```
+
+## Fluxo de Dados
+```mermaid
+graph TD
+    subgraph "Frontend (React)"
+        A[Componente de UI] -- 1. A\u00e7\u00e3o --> B(Custom Hook)
+        B -- 2. Chama A\u00e7\u00e3o --> C{Store}
+        B -- 3. Chama Servi\u00e7o --> D[Service]
+        C -- 6. Notifica Mudan\u00e7a --> B
+        B -- 7. Prov\u00ea dados --> A
+    end
+
+    subgraph "Backend/API"
+        D -- 4. Req HTTP --> E[API]
+        E -- 5. Resposta --> D
+    end
+```
+
+## Camadas
+1. **UI**: componentes e p\u00e1ginas respons\u00e1veis apenas pela renderiza\u00e7\u00e3o.
+2. **Hooks**: l\u00f3gica de UI, interagem com stores e servi\u00e7os.
+3. **Stores**: estado global usando Zustand.
+4. **Services**: abstra\u00e7\u00e3o de comunica\u00e7\u00e3o com APIs ou mocks.
+
+## Boas Pr\u00e1ticas
+- Nunca expor credenciais no front-end; use `.env`.
+- Utilizar `React.lazy` e memoiza\u00e7\u00e3o onde fizer sentido.
+- Testar servi\u00e7os, hooks e componentes de forma isolada.
+
+## Contratos e Tipos
+Todos os tipos de dom\u00ednio residem em `client/src/types`. Exemplos:
+```ts
+export interface ChatMessage {
+  id: string;
+  text: string;
+  sender: 'user' | 'agent' | 'system';
+  timestamp: string;
+}
+
+export interface AnyAgentConfig {
+  id: string;
+  name: string;
+  type: string;
+}
+```

--- a/client/src/hooks/useAgentConfigurator.ts
+++ b/client/src/hooks/useAgentConfigurator.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { AnyAgentConfig } from '@/types';
+import { useAgentStore } from '@/store/agentStore';
+import agentService from '@/services/agentService';
+
+export interface UseAgentConfiguratorReturn {
+  config: AnyAgentConfig;
+  isSaving: boolean;
+  isDirty: boolean;
+  error: Error | null;
+  updateConfig: (newConfig: Partial<AnyAgentConfig>) => void;
+  saveConfig: () => Promise<void>;
+  resetConfig: () => void;
+}
+
+export const useAgentConfigurator = (initial: AnyAgentConfig): UseAgentConfiguratorReturn => {
+  const [config, setConfig] = useState<AnyAgentConfig>(initial);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const { updateAgent } = useAgentStore();
+
+  const updateConfig = (newConfig: Partial<AnyAgentConfig>) => {
+    setConfig(prev => ({ ...prev, ...newConfig }));
+    setIsDirty(true);
+  };
+
+  const saveConfig = async () => {
+    setIsSaving(true);
+    try {
+      const saved = await agentService.saveAgent(config);
+      updateAgent(saved);
+      setIsDirty(false);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const resetConfig = () => {
+    setConfig(initial);
+    setIsDirty(false);
+  };
+
+  return { config, isSaving, isDirty, error, updateConfig, saveConfig, resetConfig };
+};
+
+export default useAgentConfigurator;

--- a/client/src/hooks/useAgents.ts
+++ b/client/src/hooks/useAgents.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import { useAgentStore } from '@/store/agentStore';
+import agentService from '@/services/agentService';
+import { AnyAgentConfig } from '@/types';
+
+export interface UseAgentsReturn {
+  agents: AnyAgentConfig[];
+  isLoading: boolean;
+  error: Error | null;
+  deleteAgent: (agentId: string) => Promise<void>;
+}
+
+export const useAgents = (): UseAgentsReturn => {
+  const { agents, loadAgents } = useAgentStore();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetch = async () => {
+      setIsLoading(true);
+      try {
+        const data = await agentService.fetchAgents();
+        loadAgents(data);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetch();
+  }, [loadAgents]);
+
+  const deleteAgent = async (id: string) => {
+    setIsLoading(true);
+    try {
+      await agentService.deleteAgent(id);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { agents, isLoading, error, deleteAgent };
+};
+
+export default useAgents;

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useSessionStore } from '@/store/sessionStore';
+import chatService from '@/services/chatService';
+import { Session, ChatMessage } from '@/types';
+
+export interface UseChatReturn {
+  sessions: Session[];
+  activeSession: Session | null;
+  messages: ChatMessage[];
+  isLoading: boolean;
+  error: Error | null;
+  sendMessage: (text: string) => Promise<void>;
+  switchSession: (sessionId: string) => void;
+}
+
+export const useChat = (): UseChatReturn => {
+  const { sessions, activeSessionId, setActiveSession } = useSessionStore();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const activeSession = sessions.find(s => s.id === activeSessionId) || null;
+
+  const sendMessage = async (text: string) => {
+    if (!activeSession) return;
+    setIsLoading(true);
+    try {
+      const msg = await chatService.sendMessage(activeSession.id, { text, sender: 'user', timestamp: new Date().toISOString() });
+      setMessages(prev => [...prev, msg]);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const switchSession = (id: string) => {
+    setActiveSession(id);
+    setMessages([]);
+  };
+
+  return { sessions, activeSession, messages, isLoading, error, sendMessage, switchSession };
+};
+
+export default useChat;

--- a/client/src/services/agentService.ts
+++ b/client/src/services/agentService.ts
@@ -1,0 +1,53 @@
+import { useAgentStore } from "@/store/agentStore";
+import { AnyAgentConfig } from '@/types';
+
+export interface IAgentService {
+  /** Retorna a lista de agentes */
+  fetchAgents(): Promise<AnyAgentConfig[]>;
+  /** Busca um agente pelo id */
+  fetchAgentById(agentId: string): Promise<AnyAgentConfig>;
+  /** Salva (cria ou atualiza) um agente */
+  saveAgent(config: AnyAgentConfig): Promise<AnyAgentConfig>;
+  /** Remove um agente */
+  deleteAgent(agentId: string): Promise<void>;
+}
+
+const SIMULATED_DELAY_MS = 300;
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const agentService: IAgentService = {
+  async fetchAgents() {
+    await delay(SIMULATED_DELAY_MS);
+    const { agents } = useAgentStore.getState();
+    return [...agents];
+  },
+
+  async fetchAgentById(agentId: string) {
+    await delay(SIMULATED_DELAY_MS);
+    const { agents } = useAgentStore.getState();
+    const found = agents.find(a => a.id === agentId);
+    if (!found) throw new Error('Agent not found');
+    return found;
+  },
+
+  async saveAgent(config: AnyAgentConfig) {
+    await delay(SIMULATED_DELAY_MS);
+    const { addAgent, updateAgent } = useAgentStore.getState();
+    let saved = { ...config };
+    if (config.id && config.id !== '') {
+      updateAgent(saved);
+    } else {
+      saved.id = crypto.randomUUID();
+      addAgent(saved);
+    }
+    return saved;
+  },
+
+  async deleteAgent(agentId: string) {
+    await delay(SIMULATED_DELAY_MS);
+    const { removeAgent } = useAgentStore.getState();
+    removeAgent(agentId);
+  },
+};
+
+export default agentService;

--- a/client/src/services/chatService.ts
+++ b/client/src/services/chatService.ts
@@ -1,0 +1,50 @@
+import { Session, ChatMessage } from '@/types';
+import { useSessionStore } from '@/store/sessionStore';
+
+export interface IChatService {
+  /** Lista as sess\u00f5es de um usu\u00e1rio */
+  fetchSessions(userId: string): Promise<Session[]>;
+  /** Carrega mensagens de uma sess\u00e3o */
+  fetchSessionMessages(sessionId: string): Promise<ChatMessage[]>;
+  /** Envia uma mensagem */
+  sendMessage(sessionId: string, message: Omit<ChatMessage, 'id'>): Promise<ChatMessage>;
+  /** Inicia uma nova sess\u00e3o */
+  startNewSession(userId: string, agentId: string): Promise<Session>;
+}
+
+const SIM_DELAY = 300;
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+export const chatService: IChatService = {
+  async fetchSessions(_userId: string) {
+    await delay(SIM_DELAY);
+    const { sessions } = useSessionStore.getState();
+    return [...sessions];
+  },
+
+  async fetchSessionMessages(sessionId: string) {
+    await delay(SIM_DELAY);
+    const { sessions } = useSessionStore.getState();
+    const session = sessions.find(s => s.id === sessionId);
+    return session ? (session as any).messages || [] : [];
+  },
+
+  async sendMessage(sessionId: string, message: Omit<ChatMessage, 'id'>) {
+    await delay(SIM_DELAY);
+    const newMessage: ChatMessage = { id: crypto.randomUUID(), ...message };
+    // aqui apenas retorna a mensagem, implementa\u00e7\u00e3o real iria atualizar o store
+    return newMessage;
+  },
+
+  async startNewSession(_userId: string, agentId: string) {
+    await delay(SIM_DELAY);
+    const newSession: Session = {
+      id: crypto.randomUUID(),
+      agentId,
+      createdAt: new Date().toISOString(),
+    } as Session;
+    return newSession;
+  },
+};
+
+export default chatService;

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -1,0 +1,14 @@
+export interface ChatMessage {
+  id: string;
+  text: string;
+  sender: 'user' | 'agent' | 'system';
+  timestamp: string;
+  senderName?: string;
+  avatarSeed?: string;
+}
+
+export interface Session {
+  id: string;
+  agentId: string;
+  createdAt: string;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './agent';
+export * from './chat';


### PR DESCRIPTION
## Summary
- document the overall project structure in `ARCHITECTURE.md`
- add mock service interfaces for agents and chat
- implement basic custom hooks (`useAgents`, `useChat`, `useAgentConfigurator`)
- centralize domain types

## Testing
- `npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_6844cc8eab94832e9781c882b5b05e1f