### PR TITLE
Add useAgentConfig hook and refactor workspace

### DIFF
--- a/client/src/api/agentService.test.ts
+++ b/client/src/api/agentService.test.ts
@@ -1,0 +1,48 @@
+import { vi, describe, beforeEach, test, expect } from 'vitest';
+import { saveAgent } from './agentService';
+import { AnyAgentConfig, AgentType, LlmAgentConfig } from '@/types/agent';
+import { useAgentStore } from '@/store/agentStore';
+
+const addAgent = vi.fn();
+const updateAgent = vi.fn();
+
+vi.mock('@/store/agentStore', () => ({
+  useAgentStore: {
+    getState: () => ({ addAgent, updateAgent }),
+  },
+}));
+
+beforeEach(() => {
+  addAgent.mockClear();
+  updateAgent.mockClear();
+});
+
+describe('agentService.saveAgent', () => {
+  const configWithoutId: LlmAgentConfig = {
+    id: '',
+    name: 'New',
+    type: AgentType.LLM,
+    instruction: '',
+    model: 'gpt',
+    code_execution: false,
+    planning_enabled: false,
+    tools: [],
+  };
+
+  const configWithId: LlmAgentConfig = {
+    ...configWithoutId,
+    id: '123',
+  };
+
+  test('calls addAgent when id is missing', async () => {
+    await saveAgent(configWithoutId);
+    expect(addAgent).toHaveBeenCalled();
+    expect(updateAgent).not.toHaveBeenCalled();
+  });
+
+  test('calls updateAgent when id exists', async () => {
+    await saveAgent(configWithId);
+    expect(updateAgent).toHaveBeenCalled();
+    expect(addAgent).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/agents/AgentConfigurator.tsx
+++ b/client/src/components/agents/AgentConfigurator.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, Dispatch, SetStateAction } from 'react';
+import React, { useState } from 'react';
+import { useAgentConfig } from '@/hooks/useAgentConfig';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
   AgentType,
@@ -42,7 +43,6 @@ import { mockInitialAgents as importedMockExistingAgents } from '@/data/mock-ini
 import { ToolSelector } from './tools/ToolSelector'; // Named import
 import AgentList from './AgentList';
 import AgentDropzone from './workflow/AgentDropzone';
-import { deepClone } from '@/lib/utils';
 
 // Cast the imported JSON to the Tool array type
 const MOCK_AVAILABLE_TOOLS: Tool[] = mockToolsDataJson as Tool[];
@@ -50,8 +50,7 @@ const MOCK_AVAILABLE_TOOLS: Tool[] = mockToolsDataJson as Tool[];
 const localMockExistingAgents: AnyAgentConfig[] = importedMockExistingAgents;
 
 interface AgentConfiguratorProps {
-  agentConfig: AnyAgentConfig; // Use shared AnyAgentConfig
-  onConfigChange: (newConfig: AnyAgentConfig) => void;
+  agentConfig: AnyAgentConfig; // Configuração inicial
   onSave?: (configToSave: AnyAgentConfig) => Promise<void>;
   isSaving?: boolean;
   isCreatingNew?: boolean;
@@ -102,14 +101,23 @@ const createNewAgentConfig = (type: AgentType, existingId?: string, existingName
   }
 };
 
+/**
+ * Componente de formulário para edição de agentes.
+ * A lógica de estado é delegada ao hook `useAgentConfig`, mantendo a UI simples.
+ */
 const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
   agentConfig: initialAgentConfig,
-  onConfigChange,
   onSave,
   isSaving = false,
   isCreatingNew = false,
 }) => {
-  const [internalConfig, setInternalConfig] = useState<AnyAgentConfig>(deepClone(initialAgentConfig));
+  const {
+    config,
+    updateConfig,
+    updateField,
+    addTool,
+    removeTool,
+  } = useAgentConfig({ initialConfig: initialAgentConfig });
   const [isToolSelectorOpen, setIsToolSelectorOpen] = useState(false);
   const [isAddSubAgentModalOpen, setIsAddSubAgentModalOpen] = useState(false);
   const [selectedAgentIdsForModal, setSelectedAgentIdsForModal] = useState<string[]>([]);
@@ -124,48 +132,39 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
     });
   };
 
-  useEffect(() => {
-    setInternalConfig(deepClone(initialAgentConfig));
-  }, [initialAgentConfig]);
-
-  const commitChange = (newConfig: AnyAgentConfig) => {
-    setInternalConfig(newConfig);
-    onConfigChange(newConfig);
-  };
-
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
-    commitChange({ ...internalConfig, [name]: value } as AnyAgentConfig); // Cast as AnyAgentConfig for base props
+    updateField(name, value);
   };
 
   const handleLlmInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    if (internalConfig.type === AgentType.LLM) {
+    if (config.type === AgentType.LLM) {
       const { name, value } = e.target;
-      commitChange({ ...internalConfig, [name]: value } as LlmAgentConfig);
+      updateField(name, value);
     }
   };
 
   const handleTypeChange = (newType: AgentType) => {
-    const newConfig = createNewAgentConfig(newType, internalConfig.id, internalConfig.name);
-    commitChange(newConfig);
+    const newConfig = createNewAgentConfig(newType, config.id, config.name);
+    updateConfig(newConfig);
   };
 
   const handleSwitchChange = (checked: boolean, name: keyof LlmAgentConfig) => {
-    if (internalConfig.type === AgentType.LLM) {
-      commitChange({ ...internalConfig, [name]: checked } as LlmAgentConfig);
+    if (config.type === AgentType.LLM) {
+      updateField(name, checked);
     }
   };
 
   const handleToolsSelectionChange = (selectedToolIds: string[]) => {
-    if (internalConfig.type === AgentType.LLM) {
-      commitChange({ ...internalConfig, tools: selectedToolIds } as LlmAgentConfig);
+    if (config.type === AgentType.LLM) {
+      updateField('tools', selectedToolIds);
     }
   };
 
   const handleRemoveTool = (toolIdToRemove: string) => {
-    if (internalConfig.type === AgentType.LLM && internalConfig.tools) {
-      const updatedTools = internalConfig.tools.filter((toolId: string) => toolId !== toolIdToRemove);
-      commitChange({ ...internalConfig, tools: updatedTools } as LlmAgentConfig);
+    if (config.type === AgentType.LLM && config.tools) {
+      const updatedTools = config.tools.filter((toolId: string) => toolId !== toolIdToRemove);
+      updateField('tools', updatedTools);
     }
   };
 
@@ -174,63 +173,61 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
       .map((id: string) => localMockExistingAgents.find((agent: AnyAgentConfig) => agent.id === id))
       .filter(Boolean) as AnyAgentConfig[];
 
-    if (internalConfig.type === AgentType.Sequential) {
-      const currentAgents = internalConfig.agents || [];
+    if (config.type === AgentType.Sequential) {
+      const currentAgents = config.agents || [];
       const newAgentIds = new Set(currentAgents.map(a => a.id));
       const uniqueNewAgents = agentsToAdd.filter(agent => !newAgentIds.has(agent.id));
-      commitChange({ ...internalConfig, agents: [...currentAgents, ...uniqueNewAgents] } as SequentialAgentConfig);
-    } else if (internalConfig.type === AgentType.Parallel) {
-      const currentAgents = internalConfig.agents || []; // parallel_agents is named 'agents' in ParallelAgentConfig type
+      updateField('agents', [...currentAgents, ...uniqueNewAgents]);
+    } else if (config.type === AgentType.Parallel) {
+      const currentAgents = config.agents || []; // parallel_agents is named 'agents' in ParallelAgentConfig type
       const newAgentIds = new Set(currentAgents.map(a => a.id));
       const uniqueNewAgents = agentsToAdd.filter(agent => !newAgentIds.has(agent.id));
-      commitChange({ ...internalConfig, agents: [...currentAgents, ...uniqueNewAgents] } as ParallelAgentConfig);
+      updateField('agents', [...currentAgents, ...uniqueNewAgents]);
     }
     setIsAddSubAgentModalOpen(false);
     setSelectedAgentIdsForModal([]);
   };
 
   const handleRemoveSubAgentFromWorkflow = (agentIdToRemove: string) => {
-    if (internalConfig.type === AgentType.Sequential) {
-      const currentAgents = internalConfig.agents || [];
+    if (config.type === AgentType.Sequential) {
+      const currentAgents = config.agents || [];
       const updatedAgents = currentAgents.filter((agent: AnyAgentConfig) => agent.id !== agentIdToRemove);
-      commitChange({ ...internalConfig, agents: updatedAgents } as SequentialAgentConfig);
-    } else if (internalConfig.type === AgentType.Parallel) {
-      const currentAgents = internalConfig.agents || []; // parallel_agents is named 'agents' in ParallelAgentConfig type
+      updateField('agents', updatedAgents);
+    } else if (config.type === AgentType.Parallel) {
+      const currentAgents = config.agents || [];
       const updatedAgents = currentAgents.filter((agent: AnyAgentConfig) => agent.id !== agentIdToRemove);
-      commitChange({ ...internalConfig, agents: updatedAgents } as ParallelAgentConfig);
+      updateField('agents', updatedAgents);
     }
   };
 
   const handleSubAgentsOrderChange = (orderedSubAgents: AnyAgentConfig[]) => {
-    if (internalConfig.type === AgentType.Sequential) {
-      commitChange({ ...internalConfig, agents: orderedSubAgents } as SequentialAgentConfig);
-    } else if (internalConfig.type === AgentType.Parallel) {
-      commitChange({ ...internalConfig, agents: orderedSubAgents } as ParallelAgentConfig);
+    if (config.type === AgentType.Sequential || config.type === AgentType.Parallel) {
+      updateField('agents', orderedSubAgents);
     }
   };
   
   const handleLoopAgentChange = (selectedAgentId: string) => {
-    if (internalConfig.type === AgentType.Loop) {
+    if (config.type === AgentType.Loop) {
       const selectedAgent = localMockExistingAgents.find((agent: AnyAgentConfig) => agent.id === selectedAgentId);
       if (selectedAgent) {
-        commitChange({ ...internalConfig, agent: selectedAgent } as LoopAgentConfig);
+        updateField('agent', selectedAgent);
       }
     }
   };
 
   const handleSavePress = async () => {
     if (onSave) {
-      await onSave(internalConfig);
+      await onSave(config);
     }
   };
 
-  const llmConfig = internalConfig.type === AgentType.LLM ? internalConfig : null;
-  const sequentialConfig = internalConfig.type === AgentType.Sequential ? internalConfig : null;
-  const parallelConfig = internalConfig.type === AgentType.Parallel ? internalConfig : null;
-  const loopConfig = internalConfig.type === AgentType.Loop ? internalConfig : null;
+  const llmConfig = config.type === AgentType.LLM ? config : null;
+  const sequentialConfig = config.type === AgentType.Sequential ? config : null;
+  const parallelConfig = config.type === AgentType.Parallel ? config : null;
+  const loopConfig = config.type === AgentType.Loop ? config : null;
 
   const isSaveDisabled = 
-    !internalConfig.name || 
+    !config.name ||
     isSaving ||
     (llmConfig && !llmConfig.instruction) ||
     (sequentialConfig && (sequentialConfig.agents?.length || 0) < 1) ||
@@ -248,7 +245,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
         <Input
           id="agentName"
           name="name"
-          value={internalConfig.name}
+          value={config.name}
           onChange={handleInputChange}
           placeholder="Ex: Agente de Pesquisa"
           style={{ marginTop: '5px' }}
@@ -257,7 +254,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
 
       <div style={{ marginBottom: '20px' }}>
         <Label htmlFor="agentType">Tipo de Agente</Label>
-        <Select value={internalConfig.type} onValueChange={(value: AgentType) => handleTypeChange(value)}>
+        <Select value={config.type} onValueChange={(value: AgentType) => handleTypeChange(value)}>
           <SelectTrigger id="agentType" style={{ marginTop: '5px' }}>
             <SelectValue placeholder="Selecione o tipo" />
           </SelectTrigger>
@@ -369,7 +366,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
                 <DialogTitle>Adicionar Agentes à Sequência</DialogTitle>
               </DialogHeader>
               <AgentList 
-                agents={localMockExistingAgents.filter((agent: AnyAgentConfig) => agent.id !== internalConfig.id && !(sequentialConfig.agents || []).find((sa: AnyAgentConfig) => sa.id === agent.id))}
+                agents={localMockExistingAgents.filter((agent: AnyAgentConfig) => agent.id !== config.id && !(sequentialConfig.agents || []).find((sa: AnyAgentConfig) => sa.id === agent.id))}
                 selectedAgentIds={selectedAgentIdsForModal}
                 onAgentToggle={handleAgentSelectionForModal}
                 selectable={true}
@@ -404,7 +401,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
                 <DialogTitle>Adicionar Agentes ao Paralelo</DialogTitle>
               </DialogHeader>
               <AgentList 
-                agents={localMockExistingAgents.filter((agent: AnyAgentConfig) => agent.id !== internalConfig.id && !(parallelConfig.agents || []).find((sa: AnyAgentConfig) => sa.id === agent.id))}
+                agents={localMockExistingAgents.filter((agent: AnyAgentConfig) => agent.id !== config.id && !(parallelConfig.agents || []).find((sa: AnyAgentConfig) => sa.id === agent.id))}
                 selectedAgentIds={selectedAgentIdsForModal}
                 onAgentToggle={handleAgentSelectionForModal}
                 selectable={true}
@@ -432,7 +429,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
             </SelectTrigger>
             <SelectContent>
               {localMockExistingAgents
-                .filter((agent: AnyAgentConfig) => agent.id !== internalConfig.id)
+                .filter((agent: AnyAgentConfig) => agent.id !== config.id)
                 .map((agent: AnyAgentConfig) => (
                   <SelectItem key={agent.id} value={agent.id}>{agent.name}</SelectItem>
               ))}

--- a/client/src/components/agents/AgentWorkspace.tsx
+++ b/client/src/components/agents/AgentWorkspace.tsx
@@ -1,9 +1,10 @@
 // src/components/agents/AgentWorkspace.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AgentType, AnyAgentConfig, LlmAgentConfig } from '@/types/agent';
 import AgentConfigurator from '@/components/agents/AgentConfigurator';
 import JsonPreview from './JsonPreview';
 import { useAgentStore } from '@/store/agentStore';
+import { useAgentConfigStore } from '@/store/agentConfigStore';
 import { deepClone } from '@/lib/utils';
 import { saveAgent } from '@/api/agentService';
 import { useToast } from '@/components/ui/use-toast';
@@ -27,29 +28,34 @@ const AgentWorkspace: React.FC = () => {
   const activeAgentFromStore = useAgentStore((state) => state.activeAgent);
   const setActiveAgentInStore = useAgentStore((state) => state.setActiveAgent);
 
-  const [currentConfig, setCurrentConfig] = useState<AnyAgentConfig>(
-    activeAgentFromStore ? deepClone(activeAgentFromStore) : deepClone(initialLlmConfig)
-  );
+  const { currentConfig, setConfig } = useAgentConfigStore((state) => ({
+    currentConfig: state.currentConfig,
+    setConfig: state.setConfig,
+  }));
   const [isCreatingNew, setIsCreatingNew] = useState(!activeAgentFromStore);
   const [isSaving, setIsSaving] = useState(false);
   const { toast } = useToast();
 
   useEffect(() => {
     // Sincroniza o workspace com o agente ativo no store
-    const agentToLoad = activeAgentFromStore || initialLlmConfig;
-    setCurrentConfig(deepClone(agentToLoad));
+    const agentToLoad = activeAgentFromStore
+      ? deepClone(activeAgentFromStore)
+      : deepClone(initialLlmConfig);
+    setConfig(agentToLoad);
     setIsCreatingNew(!activeAgentFromStore);
-  }, [activeAgentFromStore]);
+  }, [activeAgentFromStore, setConfig]);
 
   /**
    * Manipula o salvamento da configuração atual do agente,
    * exibindo toasts de sucesso ou erro.
    */
   const handleSaveCurrentConfig = async () => {
+    if (!currentConfig) return;
     setIsSaving(true);
     try {
       const savedAgent = await saveAgent(currentConfig);
       setActiveAgentInStore(savedAgent);
+      setConfig(savedAgent);
       toast({
         title: 'Agente salvo com sucesso!',
         description: `O agente "${savedAgent.name}" foi salvo.`,
@@ -72,16 +78,17 @@ const AgentWorkspace: React.FC = () => {
         <h2 className="text-lg font-semibold mb-4">
           {isCreatingNew ? 'Novo Agente' : `Editando: ${currentConfig?.name}`}
         </h2>
-        <AgentConfigurator
-          agentConfig={currentConfig}
-          onConfigChange={setCurrentConfig}
-          onSave={handleSaveCurrentConfig}
-          isSaving={isSaving}
-          isCreatingNew={isCreatingNew}
-        />
+        {currentConfig && (
+          <AgentConfigurator
+            agentConfig={currentConfig}
+            onSave={handleSaveCurrentConfig}
+            isSaving={isSaving}
+            isCreatingNew={isCreatingNew}
+          />
+        )}
       </div>
       <div style={{ flex: 1 }}>
-        <JsonPreview data={currentConfig} />
+        {currentConfig && <JsonPreview data={currentConfig} />}
       </div>
     </div>
   );

--- a/client/src/hooks/useAgentConfig.test.ts
+++ b/client/src/hooks/useAgentConfig.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAgentConfig } from './useAgentConfig';
+import { AgentType, LlmAgentConfig } from '@/types/agent';
+
+describe('useAgentConfig hook', () => {
+  const initial: LlmAgentConfig = {
+    id: '1',
+    name: 'Agent',
+    type: AgentType.LLM,
+    instruction: 'test',
+    model: 'gpt',
+    code_execution: false,
+    planning_enabled: false,
+    tools: [],
+  };
+
+  test('initializes with config', () => {
+    const { result } = renderHook(() => useAgentConfig({ initialConfig: initial }));
+    expect(result.current.config).toEqual(initial);
+  });
+
+  test('updateField updates value', () => {
+    const { result } = renderHook(() => useAgentConfig({ initialConfig: initial }));
+    act(() => {
+      result.current.updateField('name', 'New');
+    });
+    expect(result.current.config.name).toBe('New');
+  });
+
+  test('addTool and removeTool modify tools', () => {
+    const { result } = renderHook(() => useAgentConfig({ initialConfig: initial }));
+    act(() => {
+      result.current.addTool('tool1');
+    });
+    expect(result.current.config.tools).toContain('tool1');
+    act(() => {
+      result.current.removeTool('tool1');
+    });
+    expect(result.current.config.tools).not.toContain('tool1');
+  });
+
+  test('reset restores initial config', () => {
+    const { result } = renderHook(() => useAgentConfig({ initialConfig: initial }));
+    act(() => {
+      result.current.updateField('name', 'Changed');
+      result.current.reset();
+    });
+    expect(result.current.config.name).toBe(initial.name);
+  });
+});

--- a/client/src/hooks/useAgentConfig.ts
+++ b/client/src/hooks/useAgentConfig.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import { AnyAgentConfig } from '@/types/agent';
+import { deepClone } from '@/lib/utils';
+
+/**
+ * Props for useAgentConfig hook.
+ */
+export interface UseAgentConfigProps {
+  /** Initial configuration used to hydrate the local state */
+  initialConfig: AnyAgentConfig;
+}
+
+/**
+ * Hook responsável por gerenciar o estado de uma configuração de agente.
+ * Centraliza toda a lógica de atualização para manter os componentes de UI simples.
+ */
+export const useAgentConfig = ({ initialConfig }: UseAgentConfigProps) => {
+  const [config, setConfig] = useState<AnyAgentConfig>(deepClone(initialConfig));
+
+  // Atualiza o estado quando a configuração inicial mudar
+  useEffect(() => {
+    setConfig(deepClone(initialConfig));
+  }, [initialConfig]);
+
+  /**
+   * Substitui completamente a configuração atual.
+   */
+  const updateConfig = (newConfig: AnyAgentConfig) => {
+    setConfig(deepClone(newConfig));
+  };
+
+  /**
+   * Atualiza um campo simples dentro da configuração.
+   */
+  const updateField = (fieldName: string, value: unknown) => {
+    setConfig((prev) => ({ ...(prev as any), [fieldName]: value } as AnyAgentConfig));
+  };
+
+  /**
+   * Adiciona uma ferramenta ao array de ferramentas de um LlmAgentConfig.
+   */
+  const addTool = (toolId: string) => {
+    setConfig((prev) => {
+      if ((prev as any).tools) {
+        const tools = Array.from(new Set([...(prev as any).tools, toolId]));
+        return { ...(prev as any), tools } as AnyAgentConfig;
+      }
+      return prev;
+    });
+  };
+
+  /**
+   * Remove uma ferramenta do array de ferramentas.
+   */
+  const removeTool = (toolId: string) => {
+    setConfig((prev) => {
+      if ((prev as any).tools) {
+        const tools = (prev as any).tools.filter((t: string) => t !== toolId);
+        return { ...(prev as any), tools } as AnyAgentConfig;
+      }
+      return prev;
+    });
+  };
+
+  /**
+   * Atualiza uma configuração de segurança pelo índice.
+   */
+  const updateSafetySetting = (index: number, newSetting: unknown) => {
+    setConfig((prev) => {
+      const safetySettings = (prev as any).safetySettings || [];
+      const updated = [...safetySettings];
+      updated[index] = newSetting;
+      return { ...(prev as any), safetySettings: updated } as AnyAgentConfig;
+    });
+  };
+
+  /**
+   * Restaura a configuração para o valor inicial.
+   */
+  const reset = () => {
+    setConfig(deepClone(initialConfig));
+  };
+
+  return { config, updateConfig, updateField, addTool, removeTool, updateSafetySetting, reset };
+};

--- a/client/src/store/agentConfigStore.ts
+++ b/client/src/store/agentConfigStore.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+import { AnyAgentConfig } from '@/types/agent';
+
+/** Estado para edição de configurações de agente */
+interface AgentConfigState {
+  currentConfig: AnyAgentConfig | null;
+  isDirty: boolean;
+  isLoading: boolean;
+}
+
+/** Ações disponíveis no store de configuração de agente */
+interface AgentConfigActions {
+  /** Define uma nova configuração como ativa */
+  setConfig: (config: AnyAgentConfig | null) => void;
+  /** Atualiza um campo específico da configuração atual */
+  updateField: (field: string, value: unknown) => void;
+  /** Define manualmente o status de edição */
+  setIsDirty: (status: boolean) => void;
+  /** Limpa a configuração em edição */
+  reset: () => void;
+}
+
+/**
+ * Store dedicado à configuração de agente atualmente em edição.
+ */
+/**
+ * Hook Zustand que mantém a configuração de agente em edição.
+ */
+export const useAgentConfigStore = create<AgentConfigState & AgentConfigActions>(
+  (set, get) => ({
+    currentConfig: null,
+    isDirty: false,
+    isLoading: false,
+
+    setConfig: (config) => set({ currentConfig: config, isDirty: false }),
+
+    updateField: (field, value) =>
+      set((state) =>
+        state.currentConfig
+          ? {
+              currentConfig: {
+                ...(state.currentConfig as any),
+                [field]: value,
+              } as AnyAgentConfig,
+              isDirty: true,
+            }
+          : {}
+      ),
+
+    setIsDirty: (status) => set({ isDirty: status }),
+
+    reset: () => set({ currentConfig: null, isDirty: false }),
+  })
+);

--- a/docs/docs/changelog/CHANGELOG.md
+++ b/docs/docs/changelog/CHANGELOG.md
@@ -60,3 +60,10 @@
 - Removida duplicidade de interfaces e imports.
 - Ajustados caminhos de ToolSelector e AgentDropzone.
 - Primeira etapa de restauração da saúde dos componentes de agentes.
+
+### `2025-06-07`
+- **Refatoração da Lógica de Estado do AgentConfigurator**
+  - Criação do hook `useAgentConfig` centralizando a edição de `AnyAgentConfig`.
+  - Introdução do `agentConfigStore` para gerenciar o agente em edição.
+  - `AgentWorkspace` passa a orquestrar salvamentos via `agentService` e stores.
+  - Documentação atualizada com o novo fluxo e adição de testes unitários para o hook e serviço.

--- a/docs/docs/react/doc_react.md
+++ b/docs/docs/react/doc_react.md
@@ -119,6 +119,26 @@ export const useSessionStore = create<SessionState>((set) => ({
 }));
 ```
 
+### **5.1 Hook de Lógica de UI (useAgentConfig)**
+
+Para manter os componentes de formulário enxutos, criamos o hook `useAgentConfig`. Ele centraliza toda a manipulação de um `AnyAgentConfig` (adição de ferramentas, atualização de campos e restauração do estado inicial). Assim, componentes como `AgentConfigurator` apenas consomem o hook e exibem a interface.
+
+### **5.2 Divisão de Stores Zustand por Contexto**
+
+Além do `agentStore` que contém a lista mestre de agentes, agora existe o `agentConfigStore`, dedicado à configuração em edição no `AgentWorkspace`. Esse store mantém `currentConfig`, sinaliza se há alterações (`isDirty`) e facilita o reset sem afetar a lista global.
+
+```
+AgentWorkspace
+   │
+   ├── useAgentConfigStore ── currentConfig
+   │         │
+   │         └─→ AgentConfigurator (useAgentConfig)
+   │
+   └─ saveAgent ⇄ agentService ⇄ agentStore
+```
+
+
+
 ---
 
 ## **6. Comunicação com o Backend (API & Streaming)**


### PR DESCRIPTION
## Summary
- create `useAgentConfig` hook to manage agent config state
- refactor `AgentConfigurator` to use the new hook
- add `agentConfigStore` zustand store
- update `AgentWorkspace` to use the store
- add tests for hook and service
- document new architecture and update changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844cd91c5a4832eaa2781ca875fe50f