### PR TITLE
Fix agent service to use local store

### DIFF
--- a/client/src/api/agentService.ts
+++ b/client/src/api/agentService.ts
@@ -1,18 +1,51 @@
-import apiClient from './apiClient';
+// src/api/agentService.ts
 import { AnyAgentConfig } from '@/types/agent';
+import { useAgentStore } from '@/store/agentStore';
 
+const SIMULATED_DELAY_MS = 500;
+
+/**
+ * Simula um atraso de rede.
+ * @param ms - Duração do atraso em milissegundos.
+ */
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Salva (cria ou atualiza) uma configuração de agente.
+ * @param config - A configuração do agente a ser salva.
+ * @returns A configuração do agente salva (com id gerado se novo).
+ */
 export const saveAgent = async (config: AnyAgentConfig): Promise<AnyAgentConfig> => {
-  const { data } = config.id
-    ? await apiClient.put<AnyAgentConfig>(`/agents/${config.id}`, config)
-    : await apiClient.post<AnyAgentConfig>('/agents', config);
-  return data;
+  await delay(SIMULATED_DELAY_MS);
+
+  const { addAgent, updateAgent } = useAgentStore.getState();
+  let savedConfig = { ...config };
+
+  if (config.id && config.id !== '') {
+    updateAgent(savedConfig);
+  } else {
+    savedConfig.id = crypto.randomUUID();
+    addAgent(savedConfig);
+  }
+  return savedConfig;
 };
 
+/**
+ * Deleta um agente do store.
+ * @param agentId - O ID do agente a ser deletado.
+ */
 export const deleteAgent = async (agentId: string): Promise<void> => {
-  await apiClient.delete(`/agents/${agentId}`);
+  await delay(SIMULATED_DELAY_MS);
+  const { removeAgent } = useAgentStore.getState();
+  removeAgent(agentId);
 };
 
+/**
+ * Busca todos os agentes do store.
+ * @returns A lista de agentes cadastrados.
+ */
 export const fetchAgents = async (): Promise<AnyAgentConfig[]> => {
-  const { data } = await apiClient.get<AnyAgentConfig[]>('/agents');
-  return data;
+  await delay(SIMULATED_DELAY_MS / 2);
+  const { agents } = useAgentStore.getState();
+  return [...agents];
 };


### PR DESCRIPTION
## Summary
- update `agentService.ts` to manage agents via Zustand store
- keep docs and tests intact

## Testing
- `cd client && npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844d3e3e7f0832e9ec66c4ed088d44c