### PR TITLE
Refatorar componentes do configurador

### DIFF
--- a/client/src/components/features/agent-configurator/generation/AgentGenerationSettings.tsx
+++ b/client/src/components/features/agent-configurator/generation/AgentGenerationSettings.tsx
@@ -1,0 +1,84 @@
+/**
+ * @file AgentGenerationSettings.tsx
+ * @description Componente para configurar os parâmetros de geração do LLM.
+ */
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { LlmAgentConfig } from '@/types/agent';
+
+interface AgentGenerationSettingsProps {
+  config: Pick<LlmAgentConfig, 'temperature' | 'maxOutputTokens' | 'topP' | 'topK'>;
+  onNumberInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const AgentGenerationSettings: React.FC<AgentGenerationSettingsProps> = ({
+  config,
+  onNumberInputChange,
+}) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Configurações de Geração</CardTitle>
+        <CardDescription>Ajuste fino dos parâmetros de geração de resposta do LLM.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="temperature">Temperatura</Label>
+            <Input
+              id="temperature"
+              name="temperature"
+              type="number"
+              value={config.temperature}
+              onChange={onNumberInputChange}
+              placeholder="Ex: 0.7"
+              step="0.1"
+            />
+            <p className="text-sm text-muted-foreground mt-1">Controla a aleatoriedade. Menor = mais determinístico.</p>
+          </div>
+          <div>
+            <Label htmlFor="maxOutputTokens">Máximo de Tokens de Saída</Label>
+            <Input
+              id="maxOutputTokens"
+              name="maxOutputTokens"
+              type="number"
+              value={config.maxOutputTokens}
+              onChange={onNumberInputChange}
+              placeholder="Ex: 2048"
+            />
+            <p className="text-sm text-muted-foreground mt-1">Comprimento máximo da resposta gerada.</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="topP">Top P</Label>
+            <Input
+              id="topP"
+              name="topP"
+              type="number"
+              value={config.topP}
+              onChange={onNumberInputChange}
+              placeholder="Ex: 1"
+              step="0.1"
+            />
+            <p className="text-sm text-muted-foreground mt-1">Controla a diversidade via amostragem nucleus.</p>
+          </div>
+          <div>
+            <Label htmlFor="topK">Top K</Label>
+            <Input
+              id="topK"
+              name="topK"
+              type="number"
+              value={config.topK}
+              onChange={onNumberInputChange}
+              placeholder="Ex: 40"
+            />
+            <p className="text-sm text-muted-foreground mt-1">Filtra os tokens menos prováveis.</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/client/src/components/features/agent-configurator/generation/index.ts
+++ b/client/src/components/features/agent-configurator/generation/index.ts
@@ -1,0 +1,1 @@
+export * from './AgentGenerationSettings';

--- a/client/src/components/features/agent-configurator/identity/AgentIdentity.tsx
+++ b/client/src/components/features/agent-configurator/identity/AgentIdentity.tsx
@@ -1,0 +1,94 @@
+/**
+ * @file AgentIdentity.tsx
+ * @description Componente para configurar a identidade básica de um agente (nome, descrição, modelo).
+ */
+import React, { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { EditDescriptionDialog } from './EditDescriptionDialog';
+import { LlmAgentConfig } from '@/types/agent';
+
+interface AgentIdentityProps {
+  config: LlmAgentConfig;
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSelectChange: (name: keyof LlmAgentConfig, value: string) => void;
+  onDescriptionSave: (newDescription: string) => void;
+}
+
+export const AgentIdentity: React.FC<AgentIdentityProps> = ({
+  config,
+  onInputChange,
+  onSelectChange,
+  onDescriptionSave,
+}) => {
+  const [isDescriptionDialogOpen, setIsDescriptionDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Identidade do Agente</CardTitle>
+          <CardDescription>Informações básicas para identificar e descrever seu agente.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="name">Nome do Agente (Obrigatório)</Label>
+            <Input
+              id="name"
+              name="name"
+              value={config.name}
+              onChange={onInputChange}
+              placeholder="Ex: meu_agente_financeiro"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="flex justify-between items-center">
+              <Label htmlFor="descriptionDisplay">Descrição do Agente</Label>
+              <Button variant="outline" size="sm" onClick={() => setIsDescriptionDialogOpen(true)}>
+                Editar Descrição
+              </Button>
+            </div>
+            <Textarea
+              id="descriptionDisplay"
+              value={config.description}
+              readOnly
+              placeholder="Ex: Um agente para ajudar com cotações de ações."
+              rows={3}
+              className="mt-1 resize-none bg-muted cursor-pointer"
+              onClick={() => setIsDescriptionDialogOpen(true)}
+            />
+          </div>
+          <div>
+            <Label htmlFor="model">Modelo LLM (Obrigatório)</Label>
+            <Select
+              name="model"
+              value={config.model}
+              onValueChange={(value) => onSelectChange('model', value)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione um modelo" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="gemini-pro">Gemini Pro</SelectItem>
+                <SelectItem value="gemini-1.0-pro">Gemini 1.0 Pro</SelectItem>
+                <SelectItem value="gemini-1.5-pro-latest">Gemini 1.5 Pro (Latest)</SelectItem>
+                <SelectItem value="gemini-1.5-flash-latest">Gemini 1.5 Flash (Latest)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <EditDescriptionDialog
+        isOpen={isDescriptionDialogOpen}
+        onOpenChange={setIsDescriptionDialogOpen}
+        initialDescription={config.description || ''}
+        onSave={onDescriptionSave}
+      />
+    </>
+  );
+};

--- a/client/src/components/features/agent-configurator/identity/EditDescriptionDialog.tsx
+++ b/client/src/components/features/agent-configurator/identity/EditDescriptionDialog.tsx
@@ -1,0 +1,71 @@
+/**
+ * @file EditDescriptionDialog.tsx
+ * @description Dialog para editar a descrição de um agente.
+ */
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+interface EditDescriptionDialogProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  initialDescription: string;
+  onSave: (newDescription: string) => void;
+}
+
+export const EditDescriptionDialog: React.FC<EditDescriptionDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  initialDescription,
+  onSave,
+}) => {
+  const [description, setDescription] = useState(initialDescription);
+
+  useEffect(() => {
+    if (isOpen) {
+      setDescription(initialDescription);
+    }
+  }, [isOpen, initialDescription]);
+
+  const handleSave = () => {
+    onSave(description);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[625px]">
+        <DialogHeader>
+          <DialogTitle>Editar Descrição do Agente</DialogTitle>
+          <DialogDescription>
+            Forneça uma descrição clara e concisa sobre o que seu agente faz, seus objetivos e suas capacidades.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <Textarea
+            id="agent-description-editor"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Descreva o propósito e as capacidades do seu agente..."
+            rows={10}
+            className="min-h-[200px]"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSave}>Salvar Descrição</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/components/features/agent-configurator/identity/index.ts
+++ b/client/src/components/features/agent-configurator/identity/index.ts
@@ -1,0 +1,2 @@
+export * from './AgentIdentity';
+export * from './EditDescriptionDialog';

--- a/client/src/components/features/agent-configurator/index.ts
+++ b/client/src/components/features/agent-configurator/index.ts
@@ -1,0 +1,3 @@
+export * from './identity';
+export * from './instructions';
+export * from './generation';

--- a/client/src/components/features/agent-configurator/instructions/AgentInstructions.tsx
+++ b/client/src/components/features/agent-configurator/instructions/AgentInstructions.tsx
@@ -1,0 +1,59 @@
+/**
+ * @file AgentInstructions.tsx
+ * @description Componente para configurar as instruções principais (prompt) de um agente.
+ */
+import React, { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { EditInstructionDialog } from './EditInstructionDialog';
+
+interface AgentInstructionsProps {
+  instruction: string;
+  onInstructionSave: (newInstruction: string) => void;
+}
+
+export const AgentInstructions: React.FC<AgentInstructionsProps> = ({
+  instruction,
+  onInstructionSave,
+}) => {
+  const [isInstructionDialogOpen, setIsInstructionDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Instruções do Agente</CardTitle>
+          <CardDescription>Defina o comportamento principal, persona e como o agente deve operar.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1">
+            <div className="flex justify-between items-center">
+              <Label htmlFor="instructionDisplay">Instrução Principal (Prompt)</Label>
+              <Button variant="outline" size="sm" onClick={() => setIsInstructionDialogOpen(true)}>
+                Editar Instrução
+              </Button>
+            </div>
+            <Textarea
+              id="instructionDisplay"
+              value={instruction}
+              readOnly
+              placeholder="Ex: Você é um assistente prestativo que responde perguntas sobre o clima..."
+              rows={4}
+              className="mt-1 resize-none bg-muted cursor-pointer"
+              onClick={() => setIsInstructionDialogOpen(true)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <EditInstructionDialog
+        isOpen={isInstructionDialogOpen}
+        onOpenChange={setIsInstructionDialogOpen}
+        initialInstruction={instruction}
+        onSave={onInstructionSave}
+      />
+    </>
+  );
+};

--- a/client/src/components/features/agent-configurator/instructions/EditInstructionDialog.tsx
+++ b/client/src/components/features/agent-configurator/instructions/EditInstructionDialog.tsx
@@ -1,0 +1,71 @@
+/**
+ * @file EditInstructionDialog.tsx
+ * @description Dialog para editar a instrução principal de um agente.
+ */
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+interface EditInstructionDialogProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  initialInstruction: string;
+  onSave: (newInstruction: string) => void;
+}
+
+export const EditInstructionDialog: React.FC<EditInstructionDialogProps> = ({
+  isOpen,
+  onOpenChange,
+  initialInstruction,
+  onSave,
+}) => {
+  const [instruction, setInstruction] = useState(initialInstruction);
+
+  useEffect(() => {
+    if (isOpen) {
+      setInstruction(initialInstruction);
+    }
+  }, [isOpen, initialInstruction]);
+
+  const handleSave = () => {
+    onSave(instruction);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[625px]">
+        <DialogHeader>
+          <DialogTitle>Editar Instrução Principal (Prompt)</DialogTitle>
+          <DialogDescription>
+            Defina o comportamento central, a persona e as diretrizes operacionais para o seu agente.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <Textarea
+            id="agent-instruction-editor"
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            placeholder="Ex: Você é um assistente amigável e eficiente..."
+            rows={15}
+            className="min-h-[300px]"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSave}>Salvar Instrução</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/components/features/agent-configurator/instructions/index.ts
+++ b/client/src/components/features/agent-configurator/instructions/index.ts
@@ -1,0 +1,2 @@
+export * from './AgentInstructions';
+export * from './EditInstructionDialog';

--- a/client/src/types/agent.ts
+++ b/client/src/types/agent.ts
@@ -3,6 +3,7 @@ import { Tool } from "./tool";
 export interface AgentConfig {
   id: string; // Unique identifier for the agent
   name: string; // Display name for the agent
+  description?: string; // Optional description for the agent
   type: AgentType; // Type of the agent
 }
 
@@ -20,6 +21,11 @@ export interface LlmAgentConfig extends AgentConfig {
   type: AgentType.LLM;
   instruction: string;
   model: string;
+  // Generation parameters
+  temperature?: number;
+  maxOutputTokens?: number;
+  topP?: number;
+  topK?: number;
   code_execution?: boolean;
   planning_enabled?: boolean;
   tools?: string[]; // <--- Adicionar esta linha


### PR DESCRIPTION
## Summary
- add modular agent configurator components (identity, instructions and generation)
- export all feature components with index files
- extend `AgentConfig` and `LlmAgentConfig` types to include description and generation settings

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844d51bb2a0832ebb81b8ce92c2fdeb