### PR TITLE
Add tests for Agent Identity components

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,6 +36,7 @@
         "@tailwindcss/forms": "^0.5.7",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.11.0",
         "@types/react": "^18.2.0",
@@ -4793,6 +4794,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.0",

--- a/client/src/components/features/agent-configurator/identity/AgentIdentity.test.tsx
+++ b/client/src/components/features/agent-configurator/identity/AgentIdentity.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentIdentity } from './AgentIdentity';
+import { LlmAgentConfig } from '@/types/agent';
+
+vi.mock('./EditDescriptionDialog', () => ({
+  EditDescriptionDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div>Diálogo de Descrição Aberto</div> : null,
+}));
+
+describe('AgentIdentity', () => {
+  const mockConfig: Partial<LlmAgentConfig> = {
+    name: 'Agente Teste',
+    description: 'Descrição de teste.',
+    model: 'gemini-pro',
+  };
+
+  const mockOnInputChange = vi.fn();
+  const mockOnSelectChange = vi.fn();
+  const mockOnDescriptionSave = vi.fn();
+
+  it('deve renderizar os valores iniciais corretamente', () => {
+    render(
+      <AgentIdentity
+        config={mockConfig as LlmAgentConfig}
+        onInputChange={mockOnInputChange}
+        onSelectChange={mockOnSelectChange}
+        onDescriptionSave={mockOnDescriptionSave}
+      />
+    );
+
+    expect(screen.getByLabelText(/Nome do Agente/i)).toHaveValue('Agente Teste');
+    expect(screen.getByLabelText(/Descrição do Agente/i)).toHaveValue('Descrição de teste.');
+    expect(screen.getByText('Gemini Pro')).toBeInTheDocument();
+  });
+
+  it('deve chamar onInputChange quando o nome do agente é alterado', async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentIdentity
+        config={mockConfig as LlmAgentConfig}
+        onInputChange={mockOnInputChange}
+        onSelectChange={mockOnSelectChange}
+        onDescriptionSave={mockOnDescriptionSave}
+      />
+    );
+
+    const nameInput = screen.getByLabelText(/Nome do Agente/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Novo Nome');
+
+    expect(mockOnInputChange).toHaveBeenCalled();
+  });
+
+  it('deve abrir o diálogo de descrição ao clicar no botão editar', async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentIdentity
+        config={mockConfig as LlmAgentConfig}
+        onInputChange={mockOnInputChange}
+        onSelectChange={mockOnSelectChange}
+        onDescriptionSave={mockOnDescriptionSave}
+      />
+    );
+
+    expect(screen.queryByText('Diálogo de Descrição Aberto')).not.toBeInTheDocument();
+
+    const editButton = screen.getByRole('button', { name: /Editar Descrição/i });
+    await user.click(editButton);
+
+    expect(screen.getByText('Diálogo de Descrição Aberto')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/features/agent-configurator/identity/EditDescriptionDialog.test.tsx
+++ b/client/src/components/features/agent-configurator/identity/EditDescriptionDialog.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { EditDescriptionDialog } from './EditDescriptionDialog';
+
+describe('EditDescriptionDialog', () => {
+  const mockOnSave = vi.fn();
+  const mockOnOpenChange = vi.fn();
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deve chamar onSave com a nova descrição e fechar o diálogo', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditDescriptionDialog
+        isOpen={true}
+        onOpenChange={mockOnOpenChange}
+        initialDescription="Descrição inicial"
+        onSave={mockOnSave}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText(/Descreva o propósito/i);
+    await user.clear(textarea);
+    await user.type(textarea, 'Nova descrição fantástica');
+
+    const saveButton = screen.getByRole('button', { name: /Salvar Descrição/i });
+    await user.click(saveButton);
+
+    expect(mockOnSave).toHaveBeenCalledWith('Nova descrição fantástica');
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('deve fechar o diálogo ao clicar em cancelar', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditDescriptionDialog
+        isOpen={true}
+        onOpenChange={mockOnOpenChange}
+        initialDescription="Descrição inicial"
+        onSave={mockOnSave}
+      />
+    );
+
+    const cancelButton = screen.getByRole('button', { name: /Cancelar/i });
+    await user.click(cancelButton);
+
+    expect(mockOnSave).not.toHaveBeenCalled();
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/src/pages/AgentConfiguratorPage.integration.test.tsx
+++ b/client/src/pages/AgentConfiguratorPage.integration.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import AgentConfiguratorPage from './AgentConfiguratorPage';
+import * as agentService from '@/services/agentService';
+
+vi.mock('@/services/agentService', () => ({
+  saveAgentConfig: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+describe.skip('AgentConfiguratorPage Integration Flow', () => {
+  it('deve permitir que o usuário edite a descrição e veja a atualização na tela', async () => {
+    const user = userEvent.setup();
+    render(<AgentConfiguratorPage />);
+
+    const descriptionDisplay = screen.getByLabelText(/Descrição do Agente/i);
+    expect(descriptionDisplay).toHaveValue('Um agente de IA para testes.');
+
+    const editButton = screen.getByRole('button', { name: /Editar Descrição/i });
+    await user.click(editButton);
+
+    const dialogTextarea = screen.getByPlaceholderText(/Descreva o propósito/i);
+    await user.clear(dialogTextarea);
+    await user.type(dialogTextarea, 'Nova descrição integrada');
+
+    const saveButton = screen.getByRole('button', { name: /Salvar Descrição/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(descriptionDisplay).toHaveValue('Nova descrição integrada');
+  });
+
+  it('deve mostrar um erro se o nome do agente estiver em branco ao salvar', async () => {
+    const user = userEvent.setup();
+    render(<AgentConfiguratorPage />);
+
+    const nameInput = screen.getByLabelText(/Nome do Agente/i);
+    await user.clear(nameInput);
+
+    const mainSaveButton = screen.getByRole('button', { name: /Salvar Configuração do Agente/i });
+    await user.click(mainSaveButton);
+
+    expect(agentService.saveAgentConfig).not.toHaveBeenCalled();
+    expect(await screen.findByText(/O nome do agente é obrigatório/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/AgentConfiguratorPage.tsx
+++ b/client/src/pages/AgentConfiguratorPage.tsx
@@ -1,0 +1,3 @@
+export default function AgentConfiguratorPage() {
+  return <div>Stub AgentConfiguratorPage</div>;
+}


### PR DESCRIPTION
## Summary
- add `@testing-library/user-event` for simulating user interaction
- create unit tests for `AgentIdentity` and `EditDescriptionDialog`
- add skipped integration test for future `AgentConfiguratorPage`
- stub `AgentConfiguratorPage` component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844d7071f3c832ea51be70410ac0743