### PR TITLE
Refactor dashboard data flow with service and hooks

### DIFF
--- a/client/src/components/agents/CreateAgentDialog.tsx
+++ b/client/src/components/agents/CreateAgentDialog.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { AgentType } from '@/types/agent';
+
+interface CreateAgentDialogProps {
+  onConfirm: (name: string, type: AgentType) => void;
+}
+
+export const CreateAgentDialog = ({ onConfirm }: CreateAgentDialogProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [agentName, setAgentName] = useState('');
+  const [agentType, setAgentType] = useState<AgentType>(AgentType.LLM);
+
+  const handleConfirm = () => {
+    if (agentName.trim()) {
+      onConfirm(agentName, agentType);
+      setIsOpen(false);
+      setAgentName('');
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button>+ Criar Agente</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Criar Novo Agente</DialogTitle>
+          <DialogDescription>
+            Dê um nome e escolha o tipo do seu agente para começar a configuração.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="name" className="text-right">
+              Nome
+            </Label>
+            <Input
+              id="name"
+              value={agentName}
+              onChange={(e) => setAgentName(e.target.value)}
+              className="col-span-3"
+              placeholder="Ex: Agente de Atendimento"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="type" className="text-right">
+              Tipo
+            </Label>
+            <div className="col-span-3">
+              <Select value={agentType} onValueChange={(v) => setAgentType(v as AgentType)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione um tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={AgentType.LLM}>Agente LLM</SelectItem>
+                  <SelectItem value={AgentType.Sequential}>Workflow Sequencial</SelectItem>
+                  <SelectItem value={AgentType.Parallel}>Workflow Paralelo</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setIsOpen(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirm} disabled={!agentName.trim()}>
+            Criar e Configurar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateAgentDialog;

--- a/client/src/components/dashboard/AtividadeRecenteCard.tsx
+++ b/client/src/components/dashboard/AtividadeRecenteCard.tsx
@@ -42,9 +42,11 @@ const activityColors = {
 
 interface AtividadeRecenteCardProps {
   activities: Activity[];
+  isLoading?: boolean;
+  error?: string | null;
 }
 
-export function AtividadeRecenteCard({ activities }: AtividadeRecenteCardProps) {
+export function AtividadeRecenteCard({ activities, isLoading, error }: AtividadeRecenteCardProps) {
   return (
     <Card className="h-full">
       <CardHeader>
@@ -52,7 +54,11 @@ export function AtividadeRecenteCard({ activities }: AtividadeRecenteCardProps) 
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          {activities.length === 0 ? (
+          {error ? (
+            <p className="text-sm text-destructive text-center py-4">{error}</p>
+          ) : isLoading ? (
+            <p className="text-sm text-muted-foreground text-center py-4">Carregando...</p>
+          ) : activities.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-4">
               Nenhuma atividade recente
             </p>

--- a/client/src/components/dashboard/MeusAgentesCard.tsx
+++ b/client/src/components/dashboard/MeusAgentesCard.tsx
@@ -10,6 +10,9 @@ interface MeusAgentesCardProps {
   onCreateAgent: () => void;
   onAgentClick: (agent: Agent) => void;
   className?: string;
+  createButton?: React.ReactNode;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
 const statusVariantMap = {
@@ -25,41 +28,44 @@ const typeIconMap = {
   tool: '🛠️',
 } as const;
 
-export function MeusAgentesCard({ 
-  agents, 
-  onCreateAgent, 
-  onAgentClick, 
-  className = '' 
+export function MeusAgentesCard({
+  agents,
+  onCreateAgent,
+  onAgentClick,
+  className = '',
+  createButton,
+  isLoading,
+  error,
 }: MeusAgentesCardProps) {
   return (
     <Card className={`h-full flex flex-col ${className || ''}`.trim()}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-lg">Meus Agentes</CardTitle>
-        <Button 
-          size="sm" 
-          className="h-8 gap-1"
-          onClick={onCreateAgent}
-        >
-          <Plus className="h-3.5 w-3.5" />
-          <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
-            Criar Agente
-          </span>
-        </Button>
+        {createButton || (
+          <Button size="sm" className="h-8 gap-1" onClick={onCreateAgent}>
+            <Plus className="h-3.5 w-3.5" />
+            <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
+              Criar Agente
+            </span>
+          </Button>
+        )}
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto">
-        {agents.length === 0 ? (
+        {error ? (
+          <p className="text-sm text-destructive text-center py-4">{error}</p>
+        ) : isLoading ? (
+          <p className="text-sm text-muted-foreground text-center py-4">Carregando...</p>
+        ) : agents.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-center p-6">
             <p className="text-sm text-muted-foreground mb-4">
               Nenhum agente encontrado
             </p>
-            <Button 
-              size="sm" 
-              variant="outline"
-              onClick={onCreateAgent}
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              Criar seu primeiro agente
-            </Button>
+            {createButton || (
+              <Button size="sm" variant="outline" onClick={onCreateAgent}>
+                <Plus className="h-4 w-4 mr-2" />
+                Criar seu primeiro agente
+              </Button>
+            )}
           </div>
         ) : (
           <div className="space-y-3">

--- a/client/src/components/dashboard/VisaoGeralCard.tsx
+++ b/client/src/components/dashboard/VisaoGeralCard.tsx
@@ -25,12 +25,16 @@ interface VisaoGeralCardProps {
   activeAgents: number;
   activeSessions: number;
   totalSessions24h: number;
+  isLoading?: boolean;
+  error?: string | null;
 }
 
-export function VisaoGeralCard({ 
-  activeAgents, 
-  activeSessions, 
-  totalSessions24h 
+export function VisaoGeralCard({
+  activeAgents,
+  activeSessions,
+  totalSessions24h,
+  isLoading,
+  error,
 }: VisaoGeralCardProps) {
   return (
     <Card className="h-full">
@@ -38,23 +42,29 @@ export function VisaoGeralCard({
         <CardTitle className="text-lg">Visão Geral</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <StatCard
-          title="Agentes Ativos"
-          value={activeAgents}
-          icon={<LucideCpu className="h-5 w-5" />}
-        />
-        <div className="h-px bg-border" />
-        <StatCard
-          title="Sessões Ativas"
-          value={activeSessions}
-          icon={<LucideUsers className="h-5 w-5" />}
-        />
-        <div className="h-px bg-border" />
-        <StatCard
-          title="Sessões (24h)"
-          value={totalSessions24h}
-          icon={<LucideZap className="h-5 w-5" />}
-        />
+        {error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : (
+          <>
+            <StatCard
+              title="Agentes Ativos"
+              value={isLoading ? '...' : activeAgents}
+              icon={<LucideCpu className="h-5 w-5" />}
+            />
+            <div className="h-px bg-border" />
+            <StatCard
+              title="Sessões Ativas"
+              value={isLoading ? '...' : activeSessions}
+              icon={<LucideUsers className="h-5 w-5" />}
+            />
+            <div className="h-px bg-border" />
+            <StatCard
+              title="Sessões (24h)"
+              value={isLoading ? '...' : totalSessions24h}
+              icon={<LucideZap className="h-5 w-5" />}
+            />
+          </>
+        )}
       </CardContent>
     </Card>
   );

--- a/client/src/hooks/useDashboardData.ts
+++ b/client/src/hooks/useDashboardData.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useDashboardStore } from '@/store/dashboardStore';
+
+export const useDashboardData = () => {
+  const {
+    stats,
+    agents,
+    recentActivities,
+    isLoading,
+    error,
+    loadDashboardData,
+  } = useDashboardStore(state => ({
+    stats: state.stats,
+    agents: state.agents,
+    recentActivities: state.recentActivities,
+    isLoading: state.isLoading,
+    error: state.error,
+    loadDashboardData: state.loadDashboardData,
+  }));
+
+  useEffect(() => {
+    loadDashboardData();
+  }, [loadDashboardData]);
+
+  return {
+    stats,
+    agents,
+    recentActivities,
+    isLoading,
+    error,
+    refreshData: loadDashboardData,
+  };
+};
+
+export default useDashboardData;

--- a/client/src/services/dashboardService.ts
+++ b/client/src/services/dashboardService.ts
@@ -1,0 +1,36 @@
+import type { Agent, Activity } from '@/store/dashboardStore';
+
+export interface DashboardStats {
+  activeAgentsCount: number;
+  activeSessions: number;
+  totalSessions24h: number;
+}
+
+const apiDelay = () => new Promise(resolve => setTimeout(resolve, 500));
+
+export const getDashboardStats = async (): Promise<DashboardStats> => {
+  await apiDelay();
+  return {
+    activeAgentsCount: 5,
+    activeSessions: 12,
+    totalSessions24h: 147,
+  };
+};
+
+export const getRecentAgents = async (): Promise<Agent[]> => {
+  await apiDelay();
+  return [
+    { id: '1', name: 'Agente de Vendas', status: 'online', lastActive: new Date().toISOString(), type: 'llm' },
+    { id: '2', name: 'Suporte ao Cliente', status: 'busy', lastActive: new Date(Date.now() - 3e5).toISOString(), type: 'workflow' },
+    { id: '3', name: 'Análise de Dados', status: 'offline', lastActive: new Date(Date.now() - 7.2e6).toISOString(), type: 'tool' },
+  ];
+};
+
+export const getRecentActivities = async (): Promise<Activity[]> => {
+  await apiDelay();
+  return [
+    { id: '1', type: 'success', message: 'Novo agente "Análise de Dados" criado com sucesso.', timestamp: new Date().toISOString() },
+    { id: '2', type: 'info', message: 'Atualização de sistema agendada para hoje à noite.', timestamp: new Date(Date.now() - 1.8e6).toISOString() },
+    { id: '3', type: 'warning', message: 'Alta utilização de CPU no servidor principal.', timestamp: new Date(Date.now() - 7.2e6).toISOString() },
+  ];
+};

--- a/client/src/store/dashboardStore.ts
+++ b/client/src/store/dashboardStore.ts
@@ -1,10 +1,12 @@
 import { create, StateCreator } from 'zustand';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  getDashboardStats,
+  getRecentAgents,
+  getRecentActivities,
+  type DashboardStats,
+} from '@/services/dashboardService';
 
-// Type-safe ID generator
-const generateId = (): string => {
-  return uuidv4();
-};
 
 export type AgentStatus = 'online' | 'offline' | 'busy' | 'error';
 
@@ -26,108 +28,45 @@ export interface Activity {
 }
 
 interface DashboardState {
-  // Dados de agentes
+  stats: DashboardStats;
   agents: Agent[];
-  activeAgentsCount: number;
-  
-  // Dados de sessões
-  activeSessions: number;
-  totalSessions24h: number;
-  
-  // Atividades recentes
   recentActivities: Activity[];
+  isLoading: boolean;
+  error: string | null;
 }
 
 interface DashboardActions {
-  createAgent: (name: string, type: 'llm' | 'workflow' | 'tool') => void;
   updateAgentStatus: (id: string, status: AgentStatus) => void;
   addActivity: (type: Activity['type'], message: string) => void;
-  fetchDashboardData: () => Promise<void>;
+  loadDashboardData: () => Promise<void>;
 }
 
-// Dados iniciais mockados
-const MOCK_AGENTS: Agent[] = [
-  {
-    id: '1',
-    name: 'Agente de Vendas',
-    status: 'online' as const,
-    lastActive: new Date().toISOString(),
-    type: 'llm' as const,
-  },
-  {
-    id: '2',
-    name: 'Suporte ao Cliente',
-    status: 'busy' as const,
-    lastActive: new Date(Date.now() - 1000 * 60 * 5).toISOString(), // 5 minutos atrás
-    type: 'workflow' as const,
-  },
-  {
-    id: '3',
-    name: 'Análise de Dados',
-    status: 'offline' as const,
-    lastActive: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2 horas atrás
-    type: 'tool' as const,
-  },
-];
-
-const MOCK_ACTIVITIES: Activity[] = [
-  {
-    id: '1',
-    type: 'success',
-    message: 'Novo agente "Análise de Dados" criado com sucesso',
-    timestamp: new Date().toISOString(),
-  },
-  {
-    id: '2',
-    type: 'info',
-    message: 'Atualização de sistema agendada para hoje à noite',
-    timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(), // 30 minutos atrás
-  },
-  {
-    id: '3',
-    type: 'warning',
-    message: 'Alta utilização de CPU no servidor principal',
-    timestamp: new Date(Date.now() - 1000 * 60 * 120).toISOString(), // 2 horas atrás
-  },
-];
+const initialState: DashboardState = {
+  stats: { activeAgentsCount: 0, activeSessions: 0, totalSessions24h: 0 },
+  agents: [],
+  recentActivities: [],
+  isLoading: false,
+  error: null,
+};
 
 // Create the store with proper typing
 const store: StateCreator<DashboardState & DashboardActions> = (set, get) => ({
-  // Estado inicial
-  agents: [...MOCK_AGENTS],
-  activeAgentsCount: MOCK_AGENTS.filter(agent => agent.status === 'online').length,
-  activeSessions: 12,
-  totalSessions24h: 147,
-  recentActivities: [...MOCK_ACTIVITIES],
-  
+  ...initialState,
+
   // Ações
-  createAgent: (name: string, type: 'llm' | 'workflow' | 'tool') => {
-    const newAgent: Agent = {
-      id: generateId(),
-      name,
-      status: 'offline' as const,
-      lastActive: new Date().toISOString(),
-      type,
-    };
-    
-    set((state: DashboardState) => ({
-      agents: [...state.agents, newAgent],
-      activeAgentsCount: state.activeAgentsCount + (newAgent.status === 'online' ? 1 : 0),
-    }));
-    
-    // Adiciona uma atividade
-    get().addActivity('info', `Novo agente criado: ${name}`);
-  },
   
   updateAgentStatus: (id: string, status: AgentStatus) => {
     set((state: DashboardState) => {
-      const updatedAgents = state.agents.map(agent => 
+      const updatedAgents = state.agents.map(agent =>
         agent.id === id ? { ...agent, status } : agent
       );
-      
+
       return {
         agents: updatedAgents,
-        activeAgentsCount: updatedAgents.filter(a => a.status === 'online').length,
+        stats: {
+          ...state.stats,
+          activeAgentsCount: updatedAgents.filter(a => a.status === 'online').length,
+        },
       };
     });
   },
@@ -145,20 +84,26 @@ const store: StateCreator<DashboardState & DashboardActions> = (set, get) => ({
     }));
   },
   
-  fetchDashboardData: () => {
-    // Simulando uma chamada de API
-    const promise = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        set({
-          activeSessions: Math.floor(Math.random() * 100),
-          totalSessions24h: Math.floor(Math.random() * 1000),
-        });
-        get().addActivity('info', 'Dados do dashboard atualizados');
-        resolve();
-      }, 1000);
-    });
-    
-    return promise;
+  loadDashboardData: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const [stats, agents, activities] = await Promise.all([
+        getDashboardStats(),
+        getRecentAgents(),
+        getRecentActivities(),
+      ]);
+
+      set({
+        stats,
+        agents,
+        recentActivities: activities,
+        isLoading: false,
+      });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : 'Falha ao buscar dados do dashboard';
+      set({ error, isLoading: false });
+      console.error(error);
+    }
   },
 });
 


### PR DESCRIPTION
## Summary
- add `dashboardService` with mocked API calls
- overhaul `dashboardStore` to load data from the service
- introduce `useDashboardData` hook for dashboard components
- implement `CreateAgentDialog` for agent creation modal
- update dashboard cards to show loading/error states
- refactor `DashboardPage` to use new hook and dialog

## Testing
- `npm test` *(fails: output not captured due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6844db34d558832e8ed86c113db56c98