### PR TITLE
Fix dashboard page infinite loop

### DIFF
--- a/client/src/hooks/useDashboardData.ts
+++ b/client/src/hooks/useDashboardData.ts
@@ -2,21 +2,13 @@ import { useEffect } from 'react';
 import { useDashboardStore } from '@/store/dashboardStore';
 
 export const useDashboardData = () => {
-  const {
-    stats,
-    agents,
-    recentActivities,
-    isLoading,
-    error,
-    loadDashboardData,
-  } = useDashboardStore(state => ({
-    stats: state.stats,
-    agents: state.agents,
-    recentActivities: state.recentActivities,
-    isLoading: state.isLoading,
-    error: state.error,
-    loadDashboardData: state.loadDashboardData,
-  }));
+  // Select each piece of state individually to keep the snapshot stable
+  const stats = useDashboardStore(state => state.stats);
+  const agents = useDashboardStore(state => state.agents);
+  const recentActivities = useDashboardStore(state => state.recentActivities);
+  const isLoading = useDashboardStore(state => state.isLoading);
+  const error = useDashboardStore(state => state.error);
+  const loadDashboardData = useDashboardStore(state => state.loadDashboardData);
 
   useEffect(() => {
     loadDashboardData();


### PR DESCRIPTION
## Summary
- fix dashboard data hook to select each store item individually

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844e1e82370832eb2c7cfa1f9a94edd