### PR TITLE
Modernize dashboard UI

### DIFF
--- a/client/src/components/dashboard/AtividadeRecenteCard.tsx
+++ b/client/src/components/dashboard/AtividadeRecenteCard.tsx
@@ -2,6 +2,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Activity } from '@/store/dashboardStore';
 import { formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
 
 const activityIcons = {
   info: (
@@ -57,42 +59,47 @@ export function AtividadeRecenteCard({ activities, isLoading, error }: Atividade
           {error ? (
             <p className="text-sm text-destructive text-center py-4">{error}</p>
           ) : isLoading ? (
-            <p className="text-sm text-muted-foreground text-center py-4">Carregando...</p>
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-full" />
+              ))}
+            </div>
           ) : activities.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-4">
               Nenhuma atividade recente
             </p>
           ) : (
-            <div className="relative">
-              {/* Linha do tempo */}
-              <div className="absolute left-4 top-0 h-full w-0.5 bg-border -translate-x-1/2" />
-              
-              <div className="space-y-6">
-                {activities.map((activity) => (
-                  <div key={activity.id} className="relative pl-8">
-                    {/* Ponto da linha do tempo */}
-                    <div 
-                      className={`absolute left-0 top-1 flex h-4 w-4 items-center justify-center rounded-full ${activityColors[activity.type]}`}
-                    >
-                      {activityIcons[activity.type]}
+            <ScrollArea className="h-72 pr-4">
+              <div className="relative">
+                {/* Linha do tempo */}
+                <div className="absolute left-4 top-0 h-full w-0.5 bg-border -translate-x-1/2" />
+
+                <div className="space-y-6">
+                  {activities.map((activity) => (
+                    <div key={activity.id} className="relative pl-8">
+                      {/* Ponto da linha do tempo */}
+                      <div
+                        className={`absolute left-0 top-1 flex h-4 w-4 items-center justify-center rounded-full ${activityColors[activity.type]}`}
+                      >
+                        {activityIcons[activity.type]}
+                      </div>
+
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium leading-none">
+                          {activity.message}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDistanceToNow(new Date(activity.timestamp), {
+                            addSuffix: true,
+                            locale: ptBR
+                          })}
+                        </p>
+                      </div>
                     </div>
-                    
-                    <div className="space-y-1
-                    ">
-                      <p className="text-sm font-medium leading-none">
-                        {activity.message}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {formatDistanceToNow(new Date(activity.timestamp), { 
-                          addSuffix: true,
-                          locale: ptBR 
-                        })}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
+            </ScrollArea>
           )}
         </div>
       </CardContent>

--- a/client/src/components/dashboard/MeusAgentesCard.tsx
+++ b/client/src/components/dashboard/MeusAgentesCard.tsx
@@ -2,6 +2,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Plus } from 'lucide-react';
 import type { Agent } from '@/store/dashboardStore';
 
@@ -50,11 +52,15 @@ export function MeusAgentesCard({
           </Button>
         )}
       </CardHeader>
-      <CardContent className="flex-1 overflow-y-auto">
+      <CardContent className="flex-1">
         {error ? (
           <p className="text-sm text-destructive text-center py-4">{error}</p>
         ) : isLoading ? (
-          <p className="text-sm text-muted-foreground text-center py-4">Carregando...</p>
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full" />
+            ))}
+          </div>
         ) : agents.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-center p-6">
             <p className="text-sm text-muted-foreground mb-4">
@@ -68,39 +74,41 @@ export function MeusAgentesCard({
             )}
           </div>
         ) : (
-          <div className="space-y-3">
-            {agents.map((agent) => (
-              <div 
-                key={agent.id}
-                className="flex items-center p-3 rounded-lg hover:bg-accent/50 transition-colors cursor-pointer"
-                onClick={() => onAgentClick(agent)}
-              >
-                <Avatar className="h-9 w-9 mr-3">
-                  <AvatarFallback>
-                    {typeIconMap[agent.type]}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <p className="text-sm font-medium truncate">
-                      {agent.name}
+          <ScrollArea className="h-72 pr-4">
+            <div className="space-y-3">
+              {agents.map((agent) => (
+                <div
+                  key={agent.id}
+                  className="flex items-center p-3 rounded-lg hover:bg-accent/50 transition-colors cursor-pointer"
+                  onClick={() => onAgentClick(agent)}
+                >
+                  <Avatar className="h-9 w-9 mr-3">
+                    <AvatarFallback>
+                      {typeIconMap[agent.type]}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium truncate">
+                        {agent.name}
+                      </p>
+                      <Badge
+                        variant={statusVariantMap[agent.status] as any}
+                        className="text-xs"
+                      >
+                        {agent.status === 'online' ? 'Online' :
+                         agent.status === 'busy' ? 'Ocupado' :
+                         agent.status === 'error' ? 'Erro' : 'Offline'}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground truncate">
+                      Última atividade: {new Date(agent.lastActive).toLocaleTimeString()}
                     </p>
-                    <Badge 
-                      variant={statusVariantMap[agent.status] as any}
-                      className="text-xs"
-                    >
-                      {agent.status === 'online' ? 'Online' : 
-                       agent.status === 'busy' ? 'Ocupado' : 
-                       agent.status === 'error' ? 'Erro' : 'Offline'}
-                    </Badge>
                   </div>
-                  <p className="text-xs text-muted-foreground truncate">
-                    Última atividade: {new Date(agent.lastActive).toLocaleTimeString()}
-                  </p>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </ScrollArea>
         )}
       </CardContent>
     </Card>

--- a/client/src/components/dashboard/VisaoGeralCard.tsx
+++ b/client/src/components/dashboard/VisaoGeralCard.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { LucideUsers, LucideCpu, LucideZap } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface StatCardProps {
   title: string;
@@ -44,23 +45,29 @@ export function VisaoGeralCard({
       <CardContent className="space-y-4">
         {error ? (
           <p className="text-sm text-destructive">{error}</p>
+        ) : isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
         ) : (
           <>
             <StatCard
               title="Agentes Ativos"
-              value={isLoading ? '...' : activeAgents}
+              value={activeAgents}
               icon={<LucideCpu className="h-5 w-5" />}
             />
             <div className="h-px bg-border" />
             <StatCard
               title="Sessões Ativas"
-              value={isLoading ? '...' : activeSessions}
+              value={activeSessions}
               icon={<LucideUsers className="h-5 w-5" />}
             />
             <div className="h-px bg-border" />
             <StatCard
               title="Sessões (24h)"
-              value={isLoading ? '...' : totalSessions24h}
+              value={totalSessions24h}
               icon={<LucideZap className="h-5 w-5" />}
             />
           </>

--- a/client/src/components/ui/index.ts
+++ b/client/src/components/ui/index.ts
@@ -13,6 +13,9 @@ export * from "./dialog"
 export * from "./tabs"
 export * from "./table"
 export * from "./separator"
+export * from "./scroll-area"
+export * from "./skeleton"
+export * from "./progress"
 
 // Toaster and Toast components
 export * from "./toaster"

--- a/client/src/components/ui/progress.tsx
+++ b/client/src/components/ui/progress.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(({ className, value = 0, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("relative h-2 w-full overflow-hidden rounded bg-secondary", className)}
+    {...props}
+  >
+    <div
+      className="h-full bg-primary transition-all"
+      style={{ width: `${value}%` }}
+    />
+  </div>
+))
+Progress.displayName = "Progress"
+
+export { Progress }

--- a/client/src/components/ui/skeleton.tsx
+++ b/client/src/components/ui/skeleton.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn("animate-pulse rounded-md bg-muted", className)}
+        {...props}
+      />
+    )
+  }
+)
+Skeleton.displayName = "Skeleton"
+
+export { Skeleton }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@/components/ui/input';
+import { Input, Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui';
 import { Search } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import useDashboardData from '@/hooks/useDashboardData';
@@ -49,21 +49,38 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* Grid principal */}
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {/* Visão Geral */}
-        <div className="md:col-span-1 lg:row-span-2">
-          <VisaoGeralCard
-            activeAgents={stats.activeAgentsCount}
-            activeSessions={stats.activeSessions}
-            totalSessions24h={stats.totalSessions24h}
-            isLoading={isLoading}
-            error={error}
-          />
-        </div>
+      <Tabs defaultValue="overview" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="overview">Visão Geral</TabsTrigger>
+          <TabsTrigger value="agents">Agentes</TabsTrigger>
+          <TabsTrigger value="activity">Atividade</TabsTrigger>
+        </TabsList>
 
-        {/* Meus Agentes */}
-        <div className="md:col-span-1 lg:col-span-2">
+        <TabsContent value="overview">
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <div className="md:col-span-1 lg:row-span-2">
+              <VisaoGeralCard
+                activeAgents={stats.activeAgentsCount}
+                activeSessions={stats.activeSessions}
+                totalSessions24h={stats.totalSessions24h}
+                isLoading={isLoading}
+                error={error}
+              />
+            </div>
+            <div className="md:col-span-1 lg:col-span-2">
+              <MeusAgentesCard
+                agents={agents}
+                onCreateAgent={() => {}}
+                onAgentClick={handleAgentClick}
+                createButton={<CreateAgentDialog onConfirm={handleCreateAgent} />}
+                isLoading={isLoading}
+                error={error}
+              />
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="agents">
           <MeusAgentesCard
             agents={agents}
             onCreateAgent={() => {}}
@@ -72,17 +89,16 @@ export default function DashboardPage() {
             isLoading={isLoading}
             error={error}
           />
-        </div>
+        </TabsContent>
 
-        {/* Atividade Recente */}
-        <div className="md:col-span-2 lg:col-span-3">
+        <TabsContent value="activity">
           <AtividadeRecenteCard
             activities={recentActivities}
             isLoading={isLoading}
             error={error}
           />
-        </div>
-      </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `Progress` and `Skeleton` components
- export new UI components
- enhance dashboard cards with ScrollArea and loading skeletons
- reorganize Dashboard page with Tabs and modern shadcn/ui elements

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6845933446bc832e9b6c154e6bb95af4