### PR TITLE
Improve sidebar and settings UI

### DIFF
--- a/client/src/components/layouts/MainLayout.tsx
+++ b/client/src/components/layouts/MainLayout.tsx
@@ -27,7 +27,7 @@ const MainLayout = () => {
   return (
     <div className="flex h-screen w-full overflow-hidden bg-background">
       {/* Sidebar Panel */}
-      <div className="w-full sm:w-64 md:w-72 lg:w-80 xl:w-[340px] flex-none h-full overflow-y-auto border-r border-border bg-card shadow-lg dark:shadow-slate-700/50">
+      <div className="flex-none w-64 md:w-72 lg:w-80 xl:w-[340px] h-full overflow-y-auto border-r border-border bg-card shadow-lg dark:shadow-slate-700/50">
           {/* Adicionada classe 'sm:w-64' para telas pequenas e aumentada um pouco a largura em telas maiores, e adicionado shadow */}
         <Sidebar />
       </div>

--- a/client/src/components/navigation/Sidebar.tsx
+++ b/client/src/components/navigation/Sidebar.tsx
@@ -1,6 +1,6 @@
 // src/components/navigation/Sidebar.tsx - Componente da barra lateral de navegação.
-import { NavLink } from 'react-router-dom';
-import { cn } from '@/lib/utils';
+import { NavLink } from 'react-router-dom'
+import { cn } from '@/lib/utils'
 import {
   LayoutDashboard,
   Bot,
@@ -8,10 +8,13 @@ import {
   Settings,
   FlaskConical,
   FileText,
-  MessageCircle, // Added for Chat icon
-} from 'lucide-react';
-import { Avatar } from '@/components/ui/avatar'; // Added for User Avatar
-import { useAuthStore } from '@/store/authStore'; // Added for user data
+  MessageCircle,
+  Menu,
+  X,
+} from 'lucide-react'
+import { Avatar } from '@/components/ui/avatar'
+import { useAuthStore } from '@/store/authStore'
+import { useState } from 'react'
 
 type NavItem = {
   title: string;
@@ -55,38 +58,51 @@ const sidebarNavItems: NavItem[] = [
 ];
 
 export function Sidebar() {
-  const { user } = useAuthStore(); // Get user data
+  const { user } = useAuthStore();
+  const [collapsed, setCollapsed] = useState(false)
 
-  const renderNavLinks = (items: NavItem[]) => {
-    return items.map((item) => (
+  const renderNavLinks = (items: NavItem[]) =>
+    items.map((item) => (
       <NavLink
         key={item.href}
         to={item.disabled ? '#' : item.href}
         className={({ isActive }) =>
           cn(
-            'flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors mb-1',
+            'flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors',
             isActive
               ? 'bg-primary text-primary-foreground'
-              : 'text-foreground hover:bg-primary hover:text-foreground', // Updated hover state
+              : 'text-foreground hover:bg-primary hover:text-foreground',
             item.disabled && 'cursor-not-allowed opacity-50'
           )
         }
       >
-        <span className="mr-3">{item.icon}</span>
-        <span>{item.title}</span>
+        <span className="mr-3 shrink-0">{item.icon}</span>
+        {!collapsed && <span>{item.title}</span>}
       </NavLink>
-    ));
-  };
+    ))
 
   return (
-    <div className="flex h-full w-64 flex-col bg-card border-r border-border">
+    <div
+      className={cn(
+        'flex h-full flex-col bg-card border-r border-border transition-all',
+        collapsed ? 'w-16' : 'w-64'
+      )}
+    >
       {/* Sidebar Header */}
       <div className="flex h-16 items-center border-b border-border px-4">
+        <button
+          className="mr-2 rounded-md p-1 hover:bg-muted sm:hidden"
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          {collapsed ? <Menu className="h-5 w-5" /> : <X className="h-5 w-5" />}
+        </button>
         <div className="flex items-center gap-2">
           <div className="h-8 w-8 rounded-full bg-primary flex items-center justify-center">
             <span className="text-primary-foreground font-bold text-sm">N</span>
           </div>
-          <h1 className="text-lg font-semibold text-foreground">Nexus</h1>
+          {!collapsed && (
+            <h1 className="text-lg font-semibold text-foreground">Nexus</h1>
+          )}
         </div>
       </div>
 
@@ -113,16 +129,18 @@ export function Sidebar() {
             <Avatar className="h-8 w-8 shrink-0">
               <img
                 src={`https://api.dicebear.com/7.x/personas/svg?seed=${user?.name || 'user'}`}
-                alt={user?.name || 'Usuário'} // Translated alt text
+                alt={user?.name || 'Usuário'}
                 className="rounded-full"
               />
             </Avatar>
-            <div className="ml-3 flex-grow">
-              <p className="text-sm font-semibold">
-                {user?.name || 'Usuário Admin'} {/* Translated default name */}
-              </p>
-              <p className="text-xs text-muted-foreground">Minha Conta</p> {/* Label */} 
-            </div>
+            {!collapsed && (
+              <div className="ml-3 flex-grow">
+                <p className="text-sm font-semibold">
+                  {user?.name || 'Usuário Admin'}
+                </p>
+                <p className="text-xs text-muted-foreground">Minha Conta</p>
+              </div>
+            )}
             <Settings className="h-5 w-5 ml-3 opacity-75" />
           </NavLink>
         </div>

--- a/client/src/pages/Configuracoes.tsx
+++ b/client/src/pages/Configuracoes.tsx
@@ -1,9 +1,35 @@
-// src/pages/Configuracoes.tsx
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { useAuthStore } from '@/store/authStore'
+
 export default function ConfiguracoesPage() {
+  const { user, setUser } = useAuthStore()
+  const [name, setName] = useState(user?.name ?? '')
+
+  const handleSave = () => {
+    if (user) setUser({ ...user, name })
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-semibold">Página de Configurações</h1>
-      <p>Conteúdo da página de Configurações.</p>
+    <div className="mx-auto max-w-2xl space-y-6 p-4">
+      <h1 className="text-2xl font-semibold">Configura\u00e7\u00f5es</h1>
+
+      <div className="space-y-2">
+        <label htmlFor="name" className="text-sm font-medium">
+          Nome
+        </label>
+        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+        <Button onClick={handleSave} className="mt-2">
+          Salvar
+        </Button>
+      </div>
+
+      <div className="pt-4">
+        <p className="mb-2 text-sm font-medium">Tema</p>
+        <ThemeToggle />
+      </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- make Sidebar collapsible and hide labels when collapsed
- make sidebar width constant and remove extra gap in MainLayout
- improve configuration page with simple form and theme toggle

## Testing
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845ae598f64832ea51d2839b7dbf2ff