### PR TITLE
Integrate react-query for agent data

### DIFF
--- a/client/src/hooks/useAgentForm.ts
+++ b/client/src/hooks/useAgentForm.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/components/ui/use-toast';
 import { Agent, AgentType, createDefaultAgent } from '@/types/agents';

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,10 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- wrap app with `QueryClientProvider`
- use `@tanstack/react-query` in `useAgents`
- update `useAgentForm` to use new react-query import

## Testing
- `npm test` *(fails: Failed to resolve import "@/types/agent")*

------
https://chatgpt.com/codex/tasks/task_e_68475b98a224832e965659196deb1897