### PR TITLE
Implement tool service and integrate selector

### DIFF
--- a/client/src/api/toolService.test.ts
+++ b/client/src/api/toolService.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from 'vitest';
+import toolService from './toolService';
+import { useToolStore } from '@/store/toolStore';
+import { Tool } from '@/types';
+
+vi.mock('@/store/toolStore');
+
+const mockTools: Tool[] = [
+  { id: 't1', name: 'Tool 1', description: 'd1' },
+];
+
+(useToolStore as unknown as vi.Mock).getState = vi.fn(() => ({
+  tools: mockTools,
+  loadTools: vi.fn(),
+  addTool: vi.fn(),
+  updateTool: vi.fn(),
+  removeTool: vi.fn(),
+}));
+
+describe('toolService', () => {
+  test('fetchTools returns tools', async () => {
+    const tools = await toolService.fetchTools();
+    expect(tools).toEqual(mockTools);
+  });
+});

--- a/client/src/api/toolService.ts
+++ b/client/src/api/toolService.ts
@@ -1,0 +1,43 @@
+import { Tool } from '@/types';
+import { useToolStore } from '@/store/toolStore';
+import mockTools from '@/data/mock-tools.json';
+
+const SIMULATED_DELAY_MS = 300;
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface IToolService {
+  fetchTools(): Promise<Tool[]>;
+  addTool(tool: Tool): Promise<Tool>;
+  updateTool(tool: Tool): Promise<Tool>;
+  deleteTool(toolId: string): Promise<void>;
+}
+
+export const toolService: IToolService = {
+  async fetchTools() {
+    await delay(SIMULATED_DELAY_MS);
+    const { tools, loadTools } = useToolStore.getState();
+    if (tools.length === 0) {
+      loadTools(mockTools as Tool[]);
+    }
+    return [...useToolStore.getState().tools];
+  },
+
+  async addTool(tool: Tool) {
+    await delay(SIMULATED_DELAY_MS);
+    useToolStore.getState().addTool(tool);
+    return tool;
+  },
+
+  async updateTool(tool: Tool) {
+    await delay(SIMULATED_DELAY_MS);
+    useToolStore.getState().updateTool(tool);
+    return tool;
+  },
+
+  async deleteTool(toolId: string) {
+    await delay(SIMULATED_DELAY_MS);
+    useToolStore.getState().removeTool(toolId);
+  },
+};
+
+export default toolService;

--- a/client/src/components/agents/AgentConfigurator.tsx
+++ b/client/src/components/agents/AgentConfigurator.tsx
@@ -40,16 +40,14 @@ import { Slider } from '@/components/ui/slider';
 import { XIcon, Info } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
-import mockToolsDataJson from '@/data/mocks/mock-tools.json'; // Corrected import
-import { mockInitialAgents as importedMockExistingAgents } from '@/data/mocks/mock-initial-agents'; // Corrected import
+import { mockInitialAgents as importedMockExistingAgents } from '@/data/mocks/mock-initial-agents';
+import { useToolStore } from '@/store/toolStore';
 
 import { ToolSelector } from './tools/ToolSelector'; // Named import
 import AgentList from './AgentList';
 import AgentDropzone from './workflow/AgentDropzone';
 import { createNewAgentConfig } from '@/lib/agent-utils';
 
-// Cast the imported JSON to the Tool array type
-const MOCK_AVAILABLE_TOOLS: Tool[] = mockToolsDataJson as Tool[];
 // Use the imported agents directly as they should conform to AnyAgentConfig[]
 const localMockExistingAgents: AnyAgentConfig[] = importedMockExistingAgents;
 
@@ -104,7 +102,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
     onSave, // Pass onSave to the hook
     isSavingGlobal: बाहेरून_येणारे_isSaving, // Pass isSaving to the hook
   });
-  // MOCK_AVAILABLE_TOOLS is still needed for ToolSelector and rendering tool names.
+  const availableTools = useToolStore((state) => state.tools);
   // localMockExistingAgents from the component scope is used for AgentList filters.
   // The hook also returns localMockExistingAgents, decide which one to use or if they should be synced.
   // For now, assuming component's localMockExistingAgents for AgentList filters is fine.
@@ -312,7 +310,7 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
               <Label>Ferramentas Selecionadas</Label>
               <div style={{ marginTop: '10px', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
                 {llmConfig.tools?.map((toolId: string) => {
-                  const tool = MOCK_AVAILABLE_TOOLS.find((t: Tool) => t.id === toolId);
+                  const tool = availableTools.find((t: Tool) => t.id === toolId);
                   return tool ? (
                     <Badge key={toolId} variant="secondary" className="flex items-center">
                       {tool.name}
@@ -337,7 +335,6 @@ const AgentConfigurator: React.FC<AgentConfiguratorProps> = ({
                     <DialogTitle>Selecionar Ferramentas</DialogTitle>
                   </DialogHeader>
                   <ToolSelector
-                    availableTools={MOCK_AVAILABLE_TOOLS}
                     selectedTools={llmConfig.tools || []}
                     onSelectionChange={handleToolsSelectionChange}
                   />

--- a/client/src/components/agents/tools/ToolSelector.tsx
+++ b/client/src/components/agents/tools/ToolSelector.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
-import mockToolsData from '../../../data/mock-tools.json';
+import toolService from '@/api/toolService';
 import { Tool } from '@/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 interface ToolSelectorProps {
-  availableTools: Tool[]; // Ferramentas que podem ser selecionadas
   selectedTools: string[]; // IDs das ferramentas já selecionadas
   onSelectionChange: (selectedIds: string[]) => void; // Função para atualizar as ferramentas selecionadas
   // open: boolean; // Controlará a visibilidade do Dialog
@@ -14,17 +13,13 @@ interface ToolSelectorProps {
 }
 
 export const ToolSelector: React.FC<ToolSelectorProps> = ({
-  availableTools,
   selectedTools,
   onSelectionChange,
-  // open,
-  // onOpenChange
 }) => {
   const [loadedTools, setLoadedTools] = useState<Tool[]>([]);
 
   useEffect(() => {
-    // Simula o carregamento, em um cenário real seria uma chamada API
-    setLoadedTools(mockToolsData);
+    toolService.fetchTools().then(setLoadedTools);
   }, []);
 
   return (

--- a/client/src/store/toolStore.ts
+++ b/client/src/store/toolStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+import { Tool } from '@/types';
+import mockTools from '@/data/mock-tools.json';
+
+interface ToolState {
+  tools: Tool[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface ToolActions {
+  loadTools: (tools: Tool[]) => void;
+  addTool: (tool: Tool) => void;
+  updateTool: (tool: Tool) => void;
+  removeTool: (toolId: string) => void;
+}
+
+export const useToolStore = create<ToolState & ToolActions>((set) => ({
+  tools: [],
+  isLoading: false,
+  error: null,
+  loadTools: (tools) => set({ tools }),
+  addTool: (tool) => set((state) => ({ tools: [...state.tools, tool] })),
+  updateTool: (tool) =>
+    set((state) => ({ tools: state.tools.map((t) => (t.id === tool.id ? tool : t)) })),
+  removeTool: (toolId) =>
+    set((state) => ({ tools: state.tools.filter((t) => t.id !== toolId) })),
+}));
+
+// Preload mock tools on init
+useToolStore.getState().loadTools(mockTools as Tool[]);

--- a/client/src/types/agent.ts
+++ b/client/src/types/agent.ts
@@ -1,0 +1,1 @@
+export * from './core/agent';


### PR DESCRIPTION
## Summary
- add a zustand store for tools
- add toolService with basic CRUD
- update ToolSelector to load tools from service
- connect AgentConfigurator to tool store
- provide type re-export for tests
- add unit test for toolService

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68475c1d0874832e86a82c48be27f3df