### PR TITLE
Implement search filter and empty state improvements

### DIFF
--- a/client/src/components/agents/AgentList.test.tsx
+++ b/client/src/components/agents/AgentList.test.tsx
@@ -77,5 +77,18 @@ describe('AgentList Component', () => {
     expect(screen.queryByText('Agente Gamma')).not.toBeInTheDocument();
   });
 
+  test('renders call to action when list is empty and onCreateAgent provided', () => {
+    render(
+      <AgentList
+        title="Meus Agentes"
+        agents={[]}
+        onCreateAgent={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Nenhum agente encontrado.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /criar novo agente/i })).toBeInTheDocument();
+  });
+
   // Mais testes virão aqui (para seleção, exclusão, etc.)
 });

--- a/client/src/components/agents/AgentList.tsx
+++ b/client/src/components/agents/AgentList.tsx
@@ -17,6 +17,7 @@ interface AgentListProps {
   selectable?: boolean;
   activeAgentId?: string | null; // Nova prop
   searchTerm?: string; // Nova prop para busca
+  onCreateAgent?: () => void;
 }
 
 const AgentList: React.FC<AgentListProps> = ({
@@ -28,6 +29,7 @@ const AgentList: React.FC<AgentListProps> = ({
   selectable = false,
   activeAgentId,
   searchTerm = '', // Valor padrão para searchTerm
+  onCreateAgent,
 }) => {
   const agentsFromStore = useAgentStore((state: any) => state.agents);
   let displayAgents = agentsFromProps !== undefined ? agentsFromProps : agentsFromStore;
@@ -64,7 +66,16 @@ const AgentList: React.FC<AgentListProps> = ({
         <CardTitle>{currentTitle}</CardTitle>
       </CardHeader>
       <CardContent>
-        {displayAgents.length === 0 && <p className="text-sm text-muted-foreground">Nenhum agente encontrado.</p>}
+        {displayAgents.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-6 text-center space-y-3">
+            <p className="text-sm text-muted-foreground">Nenhum agente encontrado.</p>
+            {onCreateAgent && (
+              <Button variant="outline" size="sm" onClick={onCreateAgent}>
+                Criar Novo Agente
+              </Button>
+            )}
+          </div>
+        )}
         <div className="space-y-3">
           {displayAgents.map((agent: AnyAgentConfig) => (
             <div

--- a/client/src/components/agents/tools/ToolSelector.test.tsx
+++ b/client/src/components/agents/tools/ToolSelector.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { ToolSelector } from './ToolSelector';
+import toolService from '@/api/toolService';
+
+vi.mock('@/api/toolService');
+
+const mockTools = [
+  { id: '1', name: 'Search', description: 'Web search tool' },
+  { id: '2', name: 'Translate', description: 'Translation tool' },
+];
+
+vi.mocked(toolService.fetchTools).mockResolvedValue(mockTools as any);
+
+describe('ToolSelector', () => {
+  test('filters tools based on search input', async () => {
+    render(<ToolSelector selectedTools={[]} onSelectionChange={() => {}} />);
+
+    // Wait for tools to load
+    await screen.findByText('Search');
+
+    fireEvent.change(screen.getByPlaceholderText('Buscar ferramenta...'), { target: { value: 'tran' } });
+
+    expect(screen.getByText('Translate')).toBeInTheDocument();
+    expect(screen.queryByText('Search')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/agents/tools/ToolSelector.tsx
+++ b/client/src/components/agents/tools/ToolSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
 import toolService from '@/api/toolService';
 import { Tool } from '@/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -17,6 +18,7 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
   onSelectionChange,
 }) => {
   const [loadedTools, setLoadedTools] = useState<Tool[]>([]);
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
     toolService.fetchTools().then(setLoadedTools);
@@ -29,8 +31,18 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
         <CardDescription>Selecione as ferramentas que este agente pode utilizar</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="grid gap-4 py-2">
-          {loadedTools.map((tool) => (
+        <Input
+          placeholder="Buscar ferramenta..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="mb-4"
+        />
+        <div className="grid gap-4 py-2 max-h-60 overflow-y-auto">
+          {loadedTools
+            .filter((tool) =>
+              tool.name.toLowerCase().includes(search.toLowerCase())
+            )
+            .map((tool) => (
             <div key={tool.id} className="flex items-center space-x-3 p-2 hover:bg-accent/50 rounded-md">
               <Checkbox
                 id={tool.id}


### PR DESCRIPTION
## Summary
- improve the `ToolSelector` with a search input
- show a call-to-action when `AgentList` is empty
- cover these behaviours with tests

## Testing
- `npm --prefix client test` *(fails: No QueryClient set)*
- `npm --prefix client run lint` *(fails: 104 errors, 264 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684782373f08832eb210a8349e573b03