### PR TITLE
Add basic deploy tab and ADR

### DIFF
--- a/client/src/components/agents/AgentDeployTab.tsx
+++ b/client/src/components/agents/AgentDeployTab.tsx
@@ -1,0 +1,19 @@
+// client/src/components/agents/AgentDeployTab.tsx
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+export default function AgentDeployTab() {
+  const endpoint = '/api/v1/agents/{agentId}/invoke';
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Deploy</CardTitle>
+        <CardDescription>Promote this agent and view its API endpoint.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">Endpoint:</p>
+        <pre className="bg-muted p-2 rounded text-sm font-mono">{endpoint}</pre>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/agents/AgentEditor.tsx
+++ b/client/src/components/agents/AgentEditor.tsx
@@ -12,13 +12,15 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { LLMAgentForm } from './forms/LLMAgentForm';
 import { BaseAgentForm } from './forms/BaseAgentForm'; // This should provide useForm methods
 import { LLMAgent, createDefaultAgent, LLMAgentSchema } from '@/types/agents';
+import AgentDeployTab from './AgentDeployTab';
 
-const WIZARD_STEPS = ['identidade', 'instrucoes', 'ferramentas', 'revisao'];
+const WIZARD_STEPS = ['identidade', 'instrucoes', 'ferramentas', 'revisao', 'deploy'];
 const STEP_LABELS: { [key: string]: string } = {
   identidade: 'Identidade',
   instrucoes: 'Instruções',
   ferramentas: 'Ferramentas',
   revisao: 'Revisão',
+  deploy: 'Deploy',
 };
 
 // Mock data - replace with actual API calls
@@ -301,6 +303,10 @@ export function AgentEditor({ mode = 'create' }: AgentEditorProps) {
 
           <TabsContent value="revisao">
             <ReviewStep />
+          </TabsContent>
+
+          <TabsContent value="deploy">
+            <AgentDeployTab />
           </TabsContent>
         </Tabs>
 

--- a/docs/adrs/0002-agent-deploy-architecture.md
+++ b/docs/adrs/0002-agent-deploy-architecture.md
@@ -1,0 +1,17 @@
+# Agent Deployment Architecture
+
+**Status:** Proposed
+
+**Context:**
+
+Users need to expose configured agents to external applications in a secure and scalable way. The platform currently lacks a unified method to route requests to a specific agent instance while handling authentication and rate limiting.
+
+**Decision:**
+
+Introduce an API Gateway that provides a single endpoint `/api/v1/agents/{agentId}/invoke`. All external requests will hit this gateway, which will perform authentication (via API keys), rate limiting and logging. The gateway then forwards the request to the appropriate agent runtime service responsible for executing the agent.
+
+**Consequences:**
+
+- Simplifies client integration by offering a consistent endpoint format.
+- Centralizes security and monitoring concerns in the gateway layer.
+- Requires implementing the gateway and runtime routing logic, which adds infrastructure complexity.


### PR DESCRIPTION
## Summary
- document API gateway architecture for agent deployment
- add Deploy tab in AgentEditor with placeholder endpoint

## Testing
- `npx vitest run` *(fails: Discriminator property type has duplicate value undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6847f5c79578832e915d524fdf12fd04