### PR TITLE
feat: Update chat interface and navigation

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1,35 +1,53 @@
-import React from 'react';
-import MessageList from './MessageList';
-import ChatInput from './ChatInput';
-import type { ChatMessage } from './types'; // Import ChatMessage type
+// Em client/src/components/chat/ChatInterface.tsx
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
+import { ConversationList } from './ConversationList'
+import { MessageList } from './MessageList'
+import { ChatInput } from './ChatInput'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
 
-// import ToolSelector from './ToolSelector'; // ToolSelector will be integrated into ChatInput later
-
-interface ChatInterfaceProps {
-  messages: ChatMessage[];
-  onSendMessage: (messageText: string) => void;
-}
-
-const ChatInterface: React.FC<ChatInterfaceProps> = ({ messages, onSendMessage }) => {
-  // Mock messages are removed, actual messages will be passed as props
-  // const mockMessages = [
-  //   { id: '1', text: 'Hello there!', sender: 'user' as 'user' | 'agent', timestamp: new Date() },
-  //   { id: '2', text: 'Hi! How can I help you today?', sender: 'agent' as 'user' | 'agent', timestamp: new Date() },
-  // ];
+export const ChatInterface = () => {
+  // Mock do agente selecionado - isso virá do seu state manager
+  const selectedAgent = { name: 'Agente de Vendas', status: 'Online' }
 
   return (
-    // The component should probably not define its own height to 100vh if it's meant to be part of a larger page layout.
-    // Let's make it more flexible by default, e.g. height: '100%' or let the parent control it.
-    // For now, keeping style as is from Step 2, but this might need adjustment.
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', border: '1px solid #ccc', borderRadius: '8px', overflow: 'hidden' }}>
-      <div style={{ flexGrow: 1, overflowY: 'auto', padding: '16px' }}>
-        <MessageList messages={messages} />
-      </div>
-      <div style={{ borderTop: '1px solid #ccc', padding: '16px' }}>
-        <ChatInput onSendMessage={onSendMessage} />
-      </div>
-    </div>
-  );
-};
+    <ResizablePanelGroup direction="horizontal" className="flex-1 rounded-lg border">
+      <ResizablePanel defaultSize={25} minSize={20}>
+        <div className="flex h-full flex-col p-2">
+          <h2 className="p-2 text-lg font-semibold">Conversas</h2>
+          {/* 1. PAINEL DE CONVERSAS (ESQUERDA) */}
+          <ConversationList />
+        </div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={75}>
+        <div className="flex h-full flex-col">
+          {/* 2. HEADER DO CHAT */}
+          <header className="flex items-center gap-4 border-b p-4">
+            <Avatar>
+              <AvatarFallback>{selectedAgent.name.charAt(0)}</AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="font-semibold">{selectedAgent.name}</p>
+              <div className="flex items-center gap-2">
+                <Badge variant="outline" className="border-green-500 text-green-500">
+                  {selectedAgent.status}
+                </Badge>
+              </div>
+            </div>
+          </header>
 
-export default ChatInterface;
+          {/* 3. LISTA DE MENSAGENS (CENTRO) */}
+          <div className="flex-1 overflow-y-auto p-4">
+            <MessageList />
+          </div>
+
+          {/* 4. ENTRADA DE TEXTO (ABAIXO) */}
+          <div className="border-t p-4">
+            <ChatInput />
+          </div>
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -1,30 +1,13 @@
-import React from 'react';
+// Em client/src/pages/ChatPage.tsx
+import { ChatInterface } from '@/components/chat/ChatInterface'
 
-/**
- * ChatPage
- * Página de chat principal da plataforma de agentes IA.
- * Estrutura inicial seguindo o protocolo local (localrules.md).
- * Pronta para expansão com funcionalidades reais de chat, integração com backend, Zustand, etc.
- *
- * Acessibilidade e internacionalização devem ser consideradas nas próximas etapas.
- */
-const ChatPage: React.FC = () => {
-  // Estado local e hooks de integração futura podem ser adicionados aqui
-
+const ChatPage = () => {
   return (
-    <main className="flex flex-col items-center justify-center min-h-[60vh] px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">Chat do Agente IA</h1>
-      {/* Área do chat - substitua por componente real no futuro */}
-      <section
-        className="w-full max-w-xl bg-muted rounded-lg shadow p-6 flex flex-col gap-4"
-        aria-label="Área do Chat"
-      >
-        <div className="text-muted-foreground text-center">
-          Em breve: interface de chat interativa para agentes IA.
-        </div>
-      </section>
-    </main>
-  );
-};
+    <div className="flex h-[calc(100vh-theme(spacing.16))] flex-col">
+      {/* O componente ChatInterface conterá toda a lógica e layout */}
+      <ChatInterface />
+    </div>
+  )
+}
 
-export default ChatPage;
+export default ChatPage

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -63,6 +63,11 @@ const routes: AppRouteObject[] = [
         handle: { title: 'Dashboard' },
       },
       {
+        path: 'chat',
+        element: withSuspense(ChatPage),
+        handle: { title: 'Chat' },
+      },
+      {
         path: 'agents', // path changed from 'agentes'
         element: <AgentsPage />,
         handle: { title: 'Agents' }, // title changed


### PR DESCRIPTION
This commit addresses the issue of chat route accessibility and implements a new design for the chat interface.

- **Route Correction:** The chat route (`/chat`) is now correctly configured in `client/src/routes.tsx`, ensuring that `ChatPage` is rendered when the route is accessed.
- **Chat Interface Redesign:**
    - `client/src/pages/ChatPage.tsx` has been updated to a functional component that renders the main `ChatInterface`.
    - `client/src/components/chat/ChatInterface.tsx` now features a two-panel layout using ShadCN/UI's `ResizablePanelGroup`:
        - A side panel for `ConversationList`.
        - A main panel for the chat header, `MessageList`, and `ChatInput`.
    - The chat header displays mock agent information (name and status).
    - Placeholders for `ConversationList`, `MessageList`, and `ChatInput` are integrated within the new structure.