### PR TITLE
Add agent workspace panel and reasoning message

### DIFF
--- a/client/src/components/chat/AgentWorkspace.tsx
+++ b/client/src/components/chat/AgentWorkspace.tsx
@@ -1,0 +1,36 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { useChatStore } from '@/store/chatStore';
+
+export function AgentWorkspace() {
+  const { activeArtifact } = useChatStore();
+
+  const renderArtifact = () => {
+    if (!activeArtifact) {
+      return <p className="text-sm text-muted-foreground">Nenhum artefato para exibir.</p>;
+    }
+
+    switch (activeArtifact.type) {
+      case 'code':
+        return (
+          <pre className="p-4 bg-muted rounded-md text-sm whitespace-pre-wrap">
+            {activeArtifact.content}
+          </pre>
+        );
+      case 'table':
+        return <p>Renderização de Tabela aqui.</p>;
+      case 'chart':
+        return <p>Renderização de Gráfico aqui.</p>;
+      default:
+        return <p className="text-sm text-muted-foreground">Tipo de artefato não suportado.</p>;
+    }
+  };
+
+  return (
+    <Card className="h-full border-0 rounded-none">
+      <CardHeader>
+        <CardTitle>Área de Trabalho</CardTitle>
+      </CardHeader>
+      <CardContent>{renderArtifact()}</CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from 'react';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { ConversationList } from './ConversationList';
+import { AgentWorkspace } from './AgentWorkspace';
 import { useChatStore } from '@/store/chatStore';
 import { getConversationList, initialActiveConversationId } from './mockData'; // Import initialActiveConversationId
 import { MessageList } from './MessageList';
@@ -61,11 +62,11 @@ export const ChatInterface = () => {
 
   return (
     <ResizablePanelGroup direction="horizontal" className="flex-1 rounded-lg border">
-      <ResizablePanel defaultSize={25} minSize={20}>
+      <ResizablePanel defaultSize={20} minSize={15}>
         <ConversationList />
       </ResizablePanel>
       <ResizableHandle withHandle />
-      <ResizablePanel defaultSize={75}>
+      <ResizablePanel defaultSize={50} minSize={30}>
         <div className="flex h-full flex-col">
           <header className="flex items-center gap-4 border-b p-4">
             <Avatar>
@@ -93,6 +94,12 @@ export const ChatInterface = () => {
           </div>
         </div>
       </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel defaultSize={30} minSize={25}>
+        <AgentWorkspace />
+      </ResizablePanel>
     </ResizablePanelGroup>
   );
 };
+
+export default ChatInterface;

--- a/client/src/components/chat/Message.tsx
+++ b/client/src/components/chat/Message.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Bot, Zap, Wrench, Check } from 'lucide-react';
 
 // Corresponds to ChatMessage.sender but narrowed for this component's direct use
 type MessageAuthor = 'user' | 'agent';
@@ -9,13 +16,40 @@ interface MessageProps {
   author: MessageAuthor;
   content: string;
   agentName?: string; // Optional, but should be provided if author is 'agent'
+  messageType?: string;
 }
 
-const Message: React.FC<MessageProps> = ({ author, content, agentName }) => {
+const Message: React.FC<MessageProps> = ({ author, content, agentName, messageType }) => {
   const isUser = author === 'user';
 
   // Determine avatar initials
   const avatarInitial = agentName ? agentName.charAt(0).toUpperCase() : 'A';
+
+  if (messageType === 'agent_thought') {
+    return (
+      <div className="my-2">
+        <Accordion type="single" collapsible className="w-full">
+          <AccordionItem value="item-1">
+            <AccordionTrigger className="text-sm font-medium text-muted-foreground hover:no-underline">
+              <Bot className="mr-2 h-4 w-4" />
+              O agente está raciocinando...
+            </AccordionTrigger>
+            <AccordionContent className="p-4 space-y-2 border-t bg-muted/50 rounded-b-md">
+              <p className="text-xs flex items-center">
+                <Zap className="mr-2 h-3 w-3 text-yellow-500" />Iniciando a tarefa: Análise de Mercado
+              </p>
+              <p className="text-xs flex items-center">
+                <Wrench className="mr-2 h-3 w-3 text-blue-500" />Usando ferramenta: 'Web Search'
+              </p>
+              <p className="text-xs flex items-center">
+                <Check className="mr-2 h-3 w-3 text-green-500" />Ferramenta executada com sucesso.
+              </p>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/client/src/components/chat/MessageList.tsx
+++ b/client/src/components/chat/MessageList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Message from './Message';
-import { ChatMessage as MessageType } from './types'; // Using ChatMessage as MessageType
+import { ChatMessage as MessageType } from './types';
 
 interface MessageListProps {
   messages: MessageType[];
@@ -8,17 +8,16 @@ interface MessageListProps {
 
 const MessageList: React.FC<MessageListProps> = ({ messages }) => {
   return (
-    <div className="flex flex-col gap-3 p-4"> {/* Updated styling for the list container */}
-      {messages
-        .filter(msg => msg.sender === 'user' || msg.sender === 'agent') // Filter for user or agent messages
-        .map((msg) => (
-          <Message
-            key={msg.id}
-            author={msg.sender as 'user' | 'agent'} // Assert type after filtering
-            content={msg.text}
-            agentName={msg.senderName} // Pass senderName as agentName
-          />
-        ))}
+    <div className="flex flex-col gap-3 p-4">
+      {messages.map((msg) => (
+        <Message
+          key={msg.id}
+          author={(msg.sender === 'user' ? 'user' : 'agent') as 'user' | 'agent'}
+          content={msg.text}
+          agentName={msg.senderName}
+          messageType={msg.type}
+        />
+      ))}
     </div>
   );
 };

--- a/client/src/components/chat/index.ts
+++ b/client/src/components/chat/index.ts
@@ -1,9 +1,10 @@
 // client/src/components/chat/index.ts
 export { default as ChatInterface } from './ChatInterface';
-export { default as MessageList } from './MessageList'; // Previously MessageDisplayArea
+export { default as MessageList } from './MessageList';
 export { default as Message } from './Message';
-export { default as ChatInput } from './ChatInput'; // Previously MessageInput
+export { default as ChatInput } from './ChatInput';
 export { default as ToolSelector } from './ToolSelector';
-export { default as ConversationList } from './ConversationList'; // Keep if still used
-export * from './types'; // Keep if still used
-export * from './mockData'; // Keep if still used
+export { default as ConversationList } from './ConversationList';
+export * from './types';
+export * from './mockData';
+export { AgentWorkspace } from './AgentWorkspace';

--- a/client/src/components/chat/mockData.ts
+++ b/client/src/components/chat/mockData.ts
@@ -11,7 +11,7 @@ export const mockConversationsData: Record<string, ConversationMock> = {
   'conv-alpha-01': {
     id: 'conv-alpha-01',
     name: 'Agente Alpha',
-    lastMessagePreview: 'Olá! Como posso ajudar hoje?',
+    lastMessagePreview: 'O agente está raciocinando...',
     messages: [
       {
         id: 'msg1-alpha',
@@ -35,6 +35,15 @@ export const mockConversationsData: Record<string, ConversationMock> = {
         timestamp: '10:02',
         senderName: 'Agente Alpha',
         avatarSeed: 'agente-alpha-seed',
+      },
+      {
+        id: 'msg4-alpha',
+        text: '',
+        sender: 'agent',
+        timestamp: '10:03',
+        senderName: 'Agente Alpha',
+        avatarSeed: 'agente-alpha-seed',
+        type: 'agent_thought',
       },
     ],
   },

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -1,5 +1,12 @@
 // client/src/components/chat/types.ts
 
+export interface Artifact {
+  type: 'code' | 'table' | 'chart' | string;
+  language?: string;
+  content?: string;
+  data?: any;
+}
+
 export interface ChatMessage {
   id: string;
   text: string;
@@ -7,4 +14,6 @@ export interface ChatMessage {
   timestamp: string; // Usaremos string por simplicidade inicial, pode ser Date para manipulações mais complexas
   senderName?: string; // Para mensagens de agentes ou outros usuários (e.g., nome do agente)
   avatarSeed?: string; // Para gerar avatares consistentes (e.g., seed para DiceBear)
+  type?: 'text' | 'agent_thought' | 'artifact' | string;
+  artifact?: Artifact;
 }

--- a/client/src/store/chatStore.ts
+++ b/client/src/store/chatStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { ChatMessage } from '../components/chat/types'; // Import ChatMessage
+import { ChatMessage, Artifact } from '../components/chat/types'; // Import ChatMessage and Artifact
 import { getInitialMessages } from '../components/chat/mockData'; // Import mock messages function
 
 export interface Conversation {
@@ -12,16 +12,19 @@ interface ChatStore {
   conversations: Conversation[];
   selectedConversationId: string | null;
   messages: ChatMessage[]; // Add messages state
+  activeArtifact: Artifact | null;
   setSelectedConversationId: (id: string | null) => void;
   loadConversations: (conversations: Conversation[]) => void;
   loadMessages: (messages: ChatMessage[]) => void; // Add loadMessages action
   addMessage: (message: ChatMessage) => void; // Add addMessage action
+  setActiveArtifact: (artifact: Artifact | null) => void;
 }
 
 export const useChatStore = create<ChatStore>((set, get) => ({
   conversations: [],
   selectedConversationId: null,
   messages: [], // Initialize messages
+  activeArtifact: null,
   setSelectedConversationId: (id) => {
     set({ selectedConversationId: id });
     if (id === null) {
@@ -34,4 +37,5 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   loadConversations: (conversations) => set({ conversations }),
   loadMessages: (messages) => set({ messages }), // Implement loadMessages
   addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })), // Implement addMessage
+  setActiveArtifact: (artifact) => set({ activeArtifact: artifact }),
 }));

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -1,3 +1,10 @@
+export interface Artifact {
+  type: 'code' | 'table' | 'chart' | string;
+  language?: string;
+  content?: string;
+  data?: any;
+}
+
 export interface ChatMessage {
   id: string;
   text: string;
@@ -5,6 +12,8 @@ export interface ChatMessage {
   timestamp: string;
   senderName?: string;
   avatarSeed?: string;
+  type?: 'text' | 'agent_thought' | 'artifact' | string;
+  artifact?: Artifact;
 }
 
 export interface Session {


### PR DESCRIPTION
## Summary
- extend ChatMessage with `type` and `artifact`
- manage `activeArtifact` in chat store
- create `AgentWorkspace` component
- update chat interface to a three panel layout
- support agent thought messages with accordion UI
- add mock data for an agent thought example

## Testing
- `npm run lint` *(fails: 78 errors, 202 warnings)*
- `npm run test` *(fails: snapshot mismatch and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684874e0c3a8832ea6bec0f62d60b02f