### PR TITLE
Fix(layout): Improve sidebar spacing and dashboard responsiveness

### DIFF
--- a/client/src/components/layouts/MainLayout.tsx
+++ b/client/src/components/layouts/MainLayout.tsx
@@ -25,7 +25,7 @@ const MainLayout = () => {
 
 
   return (
-    <div className="flex h-screen w-full overflow-hidden bg-background">
+    <div className="flex h-screen bg-muted/40">
       <Sidebar
         isCollapsed={isSidebarCollapsed}
         onMouseEnter={() => setIsSidebarCollapsed(false)}
@@ -33,8 +33,8 @@ const MainLayout = () => {
       />
       <div
         className={cn(
-          "flex-1 flex flex-col h-full overflow-hidden transition-all duration-300 ease-in-out",
-          isSidebarCollapsed ? "ml-20" : "ml-64"
+          "flex flex-1 flex-col transition-all duration-300 ease-in-out h-full overflow-hidden",
+          isSidebarCollapsed ? "pl-20" : "pl-64"
         )}
       >
         <Topbar

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Input,
   Tabs,
@@ -53,9 +54,10 @@ export default function DashboardPage() {
   const totalTokens = tokenUsage.reduce((acc, item) => acc + item.tokens, 0)
 
   return (
-    <div className="flex-1 space-y-6 p-4 sm:p-6">
-      {/* Cabeçalho */}
-      <div className="flex flex-col justify-between space-y-2 md:flex-row md:items-center md:space-y-0">
+    <ScrollArea className="h-[calc(100vh-8rem)]">
+      <div className="space-y-6 p-4 sm:p-6">
+        {/* Cabeçalho */}
+        <div className="flex flex-col justify-between space-y-2 md:flex-row md:items-center md:space-y-0">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <div className="flex gap-4 items-center w-full md:w-auto">
           <div className="relative flex-1 md:w-64">
@@ -152,6 +154,7 @@ export default function DashboardPage() {
           />
         </TabsContent>
       </Tabs>
-    </div>
+      </div>
+    </ScrollArea>
   )
 }


### PR DESCRIPTION
This commit addresses two main layout issues:

1.  **Sidebar Spacing (MainLayout.tsx):**
    - Modified `MainLayout.tsx` to use `padding-left` on the main content container instead of `margin-left`. This provides a more robust way to handle the space occupied by the fixed-width sidebar.
    - The `padding-left` dynamically changes between `pl-20` (collapsed) and `pl-64` (expanded).
    - The root container's background is now `bg-muted/40`.
    - These changes ensure that the main content area correctly adjusts to the sidebar's state, eliminating unexpected gaps or overlaps.

2.  **Dashboard Responsiveness (Dashboard.tsx):**
    - Updated `Dashboard.tsx` to utilize the `ScrollArea` component.
    - The dashboard content is now wrapped in a `ScrollArea` with a calculated height (`h-[calc(100vh-8rem)]`), ensuring it uses the available vertical space without causing a browser-level scrollbar.
    - Scrolling for overflowing dashboard content is now handled within the `ScrollArea` component itself.
    - Removed `flex-1` from the inner content `div` as `ScrollArea` now manages the space.

These changes improve the overall UI/UX by providing a cleaner layout and a more modern application-like feel, especially on the dashboard page.