### PR TITLE
Add playground and sessions pages

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { ConversationList } from './ConversationList';
 import { AgentWorkspace } from './AgentWorkspace';
+import type { ComponentType } from 'react';
 import { useChatStore } from '@/store/chatStore';
 import { getConversationList, initialActiveConversationId } from './mockData'; // Import initialActiveConversationId
 import { MessageList } from './MessageList';
@@ -11,7 +12,11 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { ChatMessage } from './types'; // Import ChatMessage for constructing new messages
 
-export const ChatInterface = () => {
+interface ChatInterfaceProps {
+  RightPanelComponent?: ComponentType;
+}
+
+export const ChatInterface = ({ RightPanelComponent = AgentWorkspace }: ChatInterfaceProps) => {
   const {
     loadConversations,
     setSelectedConversationId,
@@ -96,7 +101,7 @@ export const ChatInterface = () => {
       </ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel defaultSize={30} minSize={25}>
-        <AgentWorkspace />
+        <RightPanelComponent />
       </ResizablePanel>
     </ResizablePanelGroup>
   );

--- a/client/src/components/chat/ReasoningPanel.tsx
+++ b/client/src/components/chat/ReasoningPanel.tsx
@@ -1,0 +1,21 @@
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+export default function ReasoningPanel() {
+  const logs = [
+    'Pensando...',
+    'Chamando ferramenta de busca...',
+    'Processando resultado...',
+  ];
+  return (
+    <div className="h-full flex flex-col">
+      <div className="p-3 border-b">
+        <h2 className="text-lg font-semibold">Racioc\u00ednio</h2>
+      </div>
+      <ScrollArea className="flex-1 p-3 space-y-2 text-sm">
+        {logs.map((log, idx) => (
+          <p key={idx}>{log}</p>
+        ))}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/client/src/components/chat/index.ts
+++ b/client/src/components/chat/index.ts
@@ -8,3 +8,4 @@ export { default as ConversationList } from './ConversationList';
 export * from './types';
 export * from './mockData';
 export { AgentWorkspace } from './AgentWorkspace';
+export { default as ReasoningPanel } from './ReasoningPanel';

--- a/client/src/components/navigation/Sidebar.tsx
+++ b/client/src/components/navigation/Sidebar.tsx
@@ -11,7 +11,9 @@ import {
   // Menu, X removed as hover will control collapse
   MessageCircle, // Added
   PlusSquare, // Added
-  // MessageCircle, FlaskConical, FileText, Database removed
+  FlaskConical,
+  History,
+  // MessageCircle, FileText, Database removed
 } from 'lucide-react'
 import { Bot } from 'lucide-react' // Using Bot icon as per plan
 import { Avatar } from '@/components/ui/avatar'
@@ -40,6 +42,11 @@ const navItems: NavItem[] = [
   },
   { href: '/chat', icon: <MessageCircle className="h-5 w-5" />, label: 'Chat' },
   {
+    href: '/playground',
+    icon: <FlaskConical className="h-5 w-5" />,
+    label: 'Playground',
+  },
+  {
     href: '/agents/new',
     icon: <PlusSquare className="h-5 w-5" />,
     label: 'Criar Agente',
@@ -51,6 +58,11 @@ const agentManagementItems: NavItem[] = [
     href: '/agents',
     icon: <Users className="h-5 w-5" />,
     label: 'Meus Agentes',
+  },
+  {
+    href: '/sessions',
+    icon: <History className="h-5 w-5" />,
+    label: 'Sessões',
   },
   { href: '/deploy', icon: <Rocket className="h-5 w-5" />, label: 'Deploy' },
 ]

--- a/client/src/data/mock-sessions.json
+++ b/client/src/data/mock-sessions.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "sess-1",
+    "agentName": "Suporte Bot",
+    "createdAt": "2024-06-01T12:00:00Z",
+    "lastActivity": "2024-06-01T12:45:00Z"
+  },
+  {
+    "id": "sess-2",
+    "agentName": "Agente de Vendas",
+    "createdAt": "2024-06-02T09:15:00Z",
+    "lastActivity": "2024-06-02T09:50:00Z"
+  },
+  {
+    "id": "sess-3",
+    "agentName": "FAQ Bot",
+    "createdAt": "2024-06-03T14:30:00Z",
+    "lastActivity": "2024-06-03T15:05:00Z"
+  }
+]

--- a/client/src/pages/Playground.tsx
+++ b/client/src/pages/Playground.tsx
@@ -1,0 +1,9 @@
+import { ChatInterface, ReasoningPanel } from '@/components/chat';
+
+export default function PlaygroundPage() {
+  return (
+    <div className="flex h-[calc(100vh-theme(spacing.16))] flex-col">
+      <ChatInterface RightPanelComponent={ReasoningPanel} />
+    </div>
+  );
+}

--- a/client/src/pages/Sessions.tsx
+++ b/client/src/pages/Sessions.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import mockSessions from '@/data/mock-sessions.json';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { MoreHorizontal } from 'lucide-react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+interface SessionRecord {
+  id: string;
+  agentName: string;
+  createdAt: string;
+  lastActivity: string;
+}
+
+export default function SessionsPage() {
+  const [sessions, setSessions] = useState<SessionRecord[]>(
+    mockSessions as SessionRecord[],
+  );
+
+  const handleDelete = (id: string) => {
+    setSessions((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Sess\u00f5es</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Hist\u00f3rico de Sess\u00f5es</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <ScrollArea className="h-[500px]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID da Sess\u00e3o</TableHead>
+                  <TableHead>Agente</TableHead>
+                  <TableHead>In\u00edcio</TableHead>
+                  <TableHead>\u00daltima Atividade</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sessions.map((session) => (
+                  <TableRow key={session.id}>
+                    <TableCell className="font-mono font-medium">
+                      {session.id}
+                    </TableCell>
+                    <TableCell>{session.agentName}</TableCell>
+                    <TableCell>
+                      {new Date(session.createdAt).toLocaleString()}
+                    </TableCell>
+                    <TableCell>
+                      {new Date(session.lastActivity).toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem>Ver Detalhes</DropdownMenuItem>
+                          <DropdownMenuItem>Exportar</DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => handleDelete(session.id)}
+                          >
+                            Excluir
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {sessions.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={5}
+                      className="text-center py-6 text-muted-foreground"
+                    >
+                      Nenhuma sess\u00e3o encontrada
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/agents/analytics.tsx
+++ b/client/src/pages/agents/analytics.tsx
@@ -1,0 +1,13 @@
+import { AgentsLayout } from '@/components/agents/AgentsLayout';
+import { TokenUsageCard } from '@/components/dashboard/TokenUsageCard';
+
+export default function AgentAnalyticsPage() {
+  return (
+    <AgentsLayout>
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold">Analytics</h2>
+        <TokenUsageCard data={[]} />
+      </div>
+    </AgentsLayout>
+  );
+}

--- a/client/src/pages/agents/settings.tsx
+++ b/client/src/pages/agents/settings.tsx
@@ -1,0 +1,20 @@
+import { AgentsLayout } from '@/components/agents/AgentsLayout';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function AgentSettingsPage() {
+  return (
+    <AgentsLayout>
+      <div className="space-y-4 max-w-md">
+        <h2 className="text-2xl font-bold">Configura\u00e7\u00f5es</h2>
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="apiKey">
+            API Key
+          </label>
+          <Input id="apiKey" placeholder="Chave" />
+        </div>
+        <Button>Salvar</Button>
+      </div>
+    </AgentsLayout>
+  );
+}

--- a/client/src/pages/agents/templates.tsx
+++ b/client/src/pages/agents/templates.tsx
@@ -1,0 +1,21 @@
+import { AgentsLayout } from '@/components/agents/AgentsLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function AgentTemplatesPage() {
+  return (
+    <AgentsLayout>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Template Exemplo</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Breve descri\u00e7\u00e3o do template.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </AgentsLayout>
+  );
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -31,6 +31,11 @@ const MemoryPage = lazy(() => import('./pages/Memory')); // Renamed from Memoria
 const Deploy = lazy(() => import('./pages/Deploy'));
 const SettingsPage = lazy(() => import('./pages/Settings')); // Renamed from Configuracoes.tsx
 const ChatPage = lazy(() => import('./pages/ChatPage'));
+const PlaygroundPage = lazy(() => import('./pages/Playground'));
+const SessionsPage = lazy(() => import('./pages/Sessions'));
+const AgentTemplatesPage = lazy(() => import('./pages/agents/templates'));
+const AgentAnalyticsPage = lazy(() => import('./pages/agents/analytics'));
+const AgentSettingsPage = lazy(() => import('./pages/agents/settings'));
 
 // Error boundary component
 // Ensure ErrorBoundary is defined before its usage or imported if defined elsewhere.
@@ -68,9 +73,34 @@ const routes: AppRouteObject[] = [
         handle: { title: 'Chat' },
       },
       {
+        path: 'playground',
+        element: withSuspense(PlaygroundPage),
+        handle: { title: 'Playground' },
+      },
+      {
+        path: 'sessions',
+        element: withSuspense(SessionsPage),
+        handle: { title: 'Sessions' },
+      },
+      {
         path: 'agents', // path changed from 'agentes'
         element: withSuspense(AgentsPage),
         handle: { title: 'Agents' }, // title changed
+      },
+      {
+        path: 'agents/templates',
+        element: withSuspense(AgentTemplatesPage),
+        handle: { title: 'Agent Templates' },
+      },
+      {
+        path: 'agents/analytics',
+        element: withSuspense(AgentAnalyticsPage),
+        handle: { title: 'Agent Analytics' },
+      },
+      {
+        path: 'agents/settings',
+        element: withSuspense(AgentSettingsPage),
+        handle: { title: 'Agent Settings' },
       },
       {
         path: 'tools', // path changed from 'ferramentas'


### PR DESCRIPTION
## Summary
- implement new Playground with reasoning panel
- show session history table
- add Agent Templates, Analytics and Settings pages
- support custom right panel in chat interface
- add routes and sidebar links
- provide mock sessions data

## Testing
- `npm test --prefix client` *(fails: Snapshot `AgentEditor > should match snapshot for create mode 1` mismatched)*

------
https://chatgpt.com/codex/tasks/task_e_6848c42a8efc832ea30162682b687b11