### PR TITLE
Improve Playground session management UI

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -10,6 +10,7 @@ import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChatMessage } from './types'; // Import ChatMessage for constructing new messages
 
 interface ChatInterfaceProps {
@@ -67,7 +68,7 @@ export const ChatInterface = ({ RightPanelComponent = AgentWorkspace }: ChatInte
 
   return (
     <ResizablePanelGroup direction="horizontal" className="flex-1 rounded-lg border">
-      <ResizablePanel defaultSize={20} minSize={15}>
+      <ResizablePanel defaultSize={25} minSize={15}>
         <ConversationList />
       </ResizablePanel>
       <ResizableHandle withHandle />
@@ -90,9 +91,9 @@ export const ChatInterface = ({ RightPanelComponent = AgentWorkspace }: ChatInte
             </div>
           </header>
 
-          <div className="flex-1 overflow-y-auto"> {/* Removed p-4, MessageList now has it */}
-            <MessageList messages={messages} /> {/* Pass messages from store */}
-          </div>
+          <ScrollArea className="flex-1">
+            <MessageList messages={messages} />
+          </ScrollArea>
 
           <div className="border-t"> {/* Removed p-4, ChatInput now has it */}
             <ChatInput onSendMessage={handleSendMessage} /> {/* Pass handler to ChatInput */}
@@ -100,7 +101,7 @@ export const ChatInterface = ({ RightPanelComponent = AgentWorkspace }: ChatInte
         </div>
       </ResizablePanel>
       <ResizableHandle withHandle />
-      <ResizablePanel defaultSize={30} minSize={25}>
+      <ResizablePanel defaultSize={25} minSize={25}>
         <RightPanelComponent />
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/client/src/components/chat/ConversationList.tsx
+++ b/client/src/components/chat/ConversationList.tsx
@@ -1,17 +1,50 @@
 // client/src/components/chat/ConversationList.tsx
 import React from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { cn } from '@/lib/utils'; // Import cn for conditional classes
-import { useChatStore } from '@/store/chatStore'; // Import useChatStore
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'; // Import Avatar components
+import { cn } from '@/lib/utils';
+import { useChatStore } from '@/store/chatStore';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Plus, MoreVertical } from 'lucide-react';
 
 const ConversationList: React.FC = () => {
-  const { conversations, selectedConversationId, setSelectedConversationId } = useChatStore();
+  const {
+    conversations,
+    selectedConversationId,
+    setSelectedConversationId,
+    addConversation,
+    renameConversation,
+    deleteConversation,
+  } = useChatStore();
+
+  const handleNewConversation = () => {
+    const id = Date.now().toString();
+    addConversation({ id, agentName: 'Nova Conversa', lastMessage: '' });
+    setSelectedConversationId(id);
+  };
+
+  const handleRename = (id: string) => {
+    const newName = prompt('Novo nome da conversa');
+    if (newName) renameConversation(id, newName);
+  };
+
+  const handleDelete = (id: string) => {
+    if (confirm('Excluir esta conversa?')) deleteConversation(id);
+  };
 
   return (
     <div className="flex h-full flex-col border-r border-border bg-card">
-      <div className="p-4 border-b border-border">
-        <h2 className="text-lg font-semibold text-foreground">Conversas</h2>
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <h2 className="text-lg font-semibold text-foreground">Sessões</h2>
+        <Button variant="outline" size="icon" onClick={handleNewConversation} aria-label="Nova Conversa">
+          <Plus className="h-4 w-4" />
+        </Button>
       </div>
       <ScrollArea className="flex-1 p-1">
         {conversations.map((convo) => (
@@ -30,10 +63,26 @@ const ConversationList: React.FC = () => {
               <p className="font-medium text-foreground text-sm truncate">{convo.agentName}</p>
               <p className="text-xs text-muted-foreground truncate">{convo.lastMessage || 'Nenhuma mensagem'}</p>
             </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Ações" onClick={(e) => e.stopPropagation()}>
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right">
+                <DropdownMenuItem onSelect={() => handleRename(convo.id)}>Renomear</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => handleDelete(convo.id)}>Excluir</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         ))}
         {conversations.length === 0 && (
-          <p className="p-3 text-sm text-muted-foreground">Nenhuma conversa ativa.</p>
+          <div className="flex flex-col items-center gap-2 p-3 text-sm text-muted-foreground">
+            <p>Inicie uma nova conversa para testar seu agente</p>
+            <Button variant="outline" size="sm" onClick={handleNewConversation}>
+              <Plus className="mr-2 h-4 w-4" /> Nova Conversa
+            </Button>
+          </div>
         )}
       </ScrollArea>
     </div>

--- a/client/src/store/chatStore.ts
+++ b/client/src/store/chatStore.ts
@@ -17,6 +17,9 @@ interface ChatStore {
   loadConversations: (conversations: Conversation[]) => void;
   loadMessages: (messages: ChatMessage[]) => void; // Add loadMessages action
   addMessage: (message: ChatMessage) => void; // Add addMessage action
+  addConversation: (conversation: Conversation) => void;
+  renameConversation: (id: string, newName: string) => void;
+  deleteConversation: (id: string) => void;
   setActiveArtifact: (artifact: Artifact | null) => void;
 }
 
@@ -37,5 +40,23 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   loadConversations: (conversations) => set({ conversations }),
   loadMessages: (messages) => set({ messages }), // Implement loadMessages
   addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })), // Implement addMessage
+  addConversation: (conversation) =>
+    set((state) => ({ conversations: [...state.conversations, conversation] })),
+  renameConversation: (id, newName) =>
+    set((state) => ({
+      conversations: state.conversations.map((c) =>
+        c.id === id ? { ...c, agentName: newName } : c
+      ),
+    })),
+  deleteConversation: (id) =>
+    set((state) => {
+      const remaining = state.conversations.filter((c) => c.id !== id);
+      const isSelected = state.selectedConversationId === id;
+      return {
+        conversations: remaining,
+        selectedConversationId: isSelected ? null : state.selectedConversationId,
+        messages: isSelected ? [] : state.messages,
+      };
+    }),
   setActiveArtifact: (artifact) => set({ activeArtifact: artifact }),
 }));


### PR DESCRIPTION
## Summary
- tweak ChatInterface layout and sizes
- add ScrollArea around messages
- add conversation actions and create button in ConversationList
- extend chat store with conversation operations

## Testing
- `npx playwright test --list` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6848d65e5c50832eaf5238a2ef36cb8e