### PR TITLE
Implement Agent Tools tab

### DIFF
--- a/client/src/api/agentService.ts
+++ b/client/src/api/agentService.ts
@@ -29,3 +29,11 @@ export const updateAgent = async (
 export const deleteAgent = async (id: string): Promise<void> => {
   await apiClient.delete(`/agents/${id}`)
 }
+
+export default {
+  fetchAgents,
+  fetchAgentById,
+  createAgent,
+  updateAgent,
+  deleteAgent,
+}

--- a/client/src/components/agents/AgentEditor.tsx
+++ b/client/src/components/agents/AgentEditor.tsx
@@ -10,6 +10,7 @@ import { FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescripti
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
 import { LLMAgentForm } from './forms/LLMAgentForm';
+import { AgentToolsTab } from './forms/AgentToolsTab';
 import { BaseAgentForm } from './forms/BaseAgentForm'; // This should provide useForm methods
 import { LLMAgent, createDefaultAgent, LLMAgentSchema } from '@/types/agents';
 // import AgentDeployTab from './AgentDeployTab'; // AgentDeployTab removed as per new tab structure
@@ -271,7 +272,7 @@ export function AgentEditor({ mode = 'create' }: AgentEditorProps) {
                 <CardDescription>Configure as ferramentas e capacidades do seu agente.</CardDescription>
               </CardHeader>
               <CardContent>
-                <p className="text-muted-foreground">Em breve: Funcionalidade de configuração de ferramentas.</p>
+                <AgentToolsTab />
               </CardContent>
             </Card>
           </TabsContent>

--- a/client/src/components/agents/__snapshots__/AgentEditor.test.tsx.snap
+++ b/client/src/components/agents/__snapshots__/AgentEditor.test.tsx.snap
@@ -61,6 +61,20 @@ exports[`AgentEditor > should match snapshot for create mode 1`] = `
               Instruções
             </button>
             <button
+              aria-controls="radix-:r0:-content-modelo_geracao"
+              aria-selected="false"
+              class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+              data-orientation="horizontal"
+              data-radix-collection-item=""
+              data-state="inactive"
+              id="radix-:r0:-trigger-modelo_geracao"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              Modelo & Geração
+            </button>
+            <button
               aria-controls="radix-:r0:-content-ferramentas"
               aria-selected="false"
               class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
@@ -75,32 +89,18 @@ exports[`AgentEditor > should match snapshot for create mode 1`] = `
               Ferramentas
             </button>
             <button
-              aria-controls="radix-:r0:-content-revisao"
+              aria-controls="radix-:r0:-content-memoria"
               aria-selected="false"
               class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
               data-orientation="horizontal"
               data-radix-collection-item=""
               data-state="inactive"
-              id="radix-:r0:-trigger-revisao"
+              id="radix-:r0:-trigger-memoria"
               role="tab"
               tabindex="-1"
               type="button"
             >
-              Revisão
-            </button>
-            <button
-              aria-controls="radix-:r0:-content-deploy"
-              aria-selected="false"
-              class="inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
-              data-orientation="horizontal"
-              data-radix-collection-item=""
-              data-state="inactive"
-              id="radix-:r0:-trigger-deploy"
-              role="tab"
-              tabindex="-1"
-              type="button"
-            >
-              Deploy
+              Memória
             </button>
           </div>
           <div
@@ -204,6 +204,16 @@ exports[`AgentEditor > should match snapshot for create mode 1`] = `
             tabindex="0"
           />
           <div
+            aria-labelledby="radix-:r0:-trigger-modelo_geracao"
+            class="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            data-orientation="horizontal"
+            data-state="inactive"
+            hidden=""
+            id="radix-:r0:-content-modelo_geracao"
+            role="tabpanel"
+            tabindex="0"
+          />
+          <div
             aria-labelledby="radix-:r0:-trigger-ferramentas"
             class="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             data-orientation="horizontal"
@@ -214,37 +224,18 @@ exports[`AgentEditor > should match snapshot for create mode 1`] = `
             tabindex="0"
           />
           <div
-            aria-labelledby="radix-:r0:-trigger-revisao"
+            aria-labelledby="radix-:r0:-trigger-memoria"
             class="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             data-orientation="horizontal"
             data-state="inactive"
             hidden=""
-            id="radix-:r0:-content-revisao"
-            role="tabpanel"
-            tabindex="0"
-          />
-          <div
-            aria-labelledby="radix-:r0:-trigger-deploy"
-            class="mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            data-orientation="horizontal"
-            data-state="inactive"
-            hidden=""
-            id="radix-:r0:-content-deploy"
+            id="radix-:r0:-content-memoria"
             role="tabpanel"
             tabindex="0"
           />
         </div>
         <div
-          class="block mt-6"
-        >
-          <div
-            data-testid="mock-llm-agent-form"
-          >
-            LLMAgentForm Mock
-          </div>
-        </div>
-        <div
-          class="flex justify-between items-center mt-8 pt-6 border-t border-gray-200 dark:border-gray-700"
+          class="flex justify-between items-center mt-8 pt-6 border-t"
         >
           <div>
             <button
@@ -289,6 +280,6 @@ exports[`AgentEditor > should match snapshot for create mode 1`] = `
       </div>
     </form>
   </div>
-
+   
 </div>
 `;

--- a/client/src/components/agents/forms/AgentToolsTab.test.tsx
+++ b/client/src/components/agents/forms/AgentToolsTab.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { vi } from 'vitest';
+import { AgentToolsTab } from './AgentToolsTab';
+import toolService from '@/api/toolService';
+import { LLMAgentSchema, LLMAgent } from '@/types/agents';
+
+vi.mock('@/api/toolService');
+
+const mockTools = [
+  { id: 'web_search', name: 'Web Search', description: 'Search the web' },
+  { id: 'calculator', name: 'Calculator', description: 'Do math' },
+];
+
+(toolService.fetchTools as unknown as vi.Mock).mockResolvedValue(mockTools);
+
+function renderWithForm(initial?: Partial<LLMAgent>) {
+  const methods = useForm<LLMAgent>({ defaultValues: { ...LLMAgentSchema.parse({}), ...initial } });
+  const utils = render(
+    <FormProvider {...methods}>
+      <AgentToolsTab />
+    </FormProvider>
+  );
+  return { methods, ...utils };
+}
+
+describe('AgentToolsTab', () => {
+  it('loads and selects tools', async () => {
+    const { methods } = renderWithForm();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Web Search')).toBeInTheDocument();
+    });
+
+    const checkbox = screen.getByLabelText('Web Search');
+    await userEvent.click(checkbox);
+    expect(methods.getValues('tools')).toContain('web_search');
+  });
+});

--- a/client/src/components/agents/forms/AgentToolsTab.tsx
+++ b/client/src/components/agents/forms/AgentToolsTab.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Tool } from '@/types';
+import toolService from '@/api/toolService';
+import { Checkbox } from '@/components/ui/checkbox';
+import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Label } from '@/components/ui/label';
+import { LLMAgent } from '@/types/agents';
+
+export function AgentToolsTab() {
+  const { control } = useFormContext<LLMAgent>();
+  const [tools, setTools] = useState<Tool[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadTools = async () => {
+      try {
+        const fetched = await toolService.fetchTools();
+        setTools(fetched);
+      } catch (err) {
+        setError('Failed to load tools');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadTools();
+  }, []);
+
+  if (isLoading) {
+    return <p>Loading tools...</p>;
+  }
+
+  if (error) {
+    return <p className="text-destructive">{error}</p>;
+  }
+
+  return (
+    <FormField
+      control={control}
+      name="tools"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel className="sr-only">Ferramentas</FormLabel>
+          <FormControl>
+            <div className="space-y-3">
+              {tools.map((tool) => {
+                const checked = field.value?.includes(tool.id);
+                const handleChange = (checked: boolean) => {
+                  const current = field.value || [];
+                  if (checked) {
+                    field.onChange([...current, tool.id]);
+                  } else {
+                    field.onChange(current.filter((id: string) => id !== tool.id));
+                  }
+                };
+                return (
+                  <div key={tool.id} className="flex items-start gap-3">
+                    <Checkbox
+                      id={`tool-${tool.id}`}
+                      checked={checked}
+                      onCheckedChange={handleChange}
+                    />
+                    <Label htmlFor={`tool-${tool.id}`} className="font-medium">
+                      {tool.name}
+                    </Label>
+                    <span className="text-sm text-muted-foreground">{tool.description}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+export default AgentToolsTab;

--- a/client/src/lib/form-utils.ts
+++ b/client/src/lib/form-utils.ts
@@ -27,6 +27,7 @@ export const llmAgentSchema = z.object({
   topK: z.number().min(1).max(100).default(40),
   instruction: z.string().min(1, 'Instructions are required'),
   systemPrompt: z.string().optional(),
+  tools: z.array(z.string()).default([]),
   stopSequences: z.array(z.string()).default([]),
   frequencyPenalty: z.number().min(-2).max(2).default(0),
   presencePenalty: z.number().min(-2).max(2).default(0),

--- a/client/src/types/agents/index.ts
+++ b/client/src/types/agents/index.ts
@@ -9,8 +9,8 @@ export const BaseAgentSchema = z.object({
   version: z.string().default('1.0.0'),
   isPublic: z.boolean().default(false),
   tags: z.array(z.string()).default([]),
-  createdAt: z.string().default(() => new Date().toISO()),
-  updatedAt: z.string().default(() => new Date().toISO()),
+  createdAt: z.string().default(() => new Date().toISOString()),
+  updatedAt: z.string().default(() => new Date().toISOString()),
 });
 
 export type BaseAgent = z.infer<typeof BaseAgentSchema>;
@@ -29,6 +29,7 @@ export const LLMAgentSchema = BaseAgentSchema.extend({
   instruction: z.string().default(''),
   systemPrompt: z.string().default(''),
   avatarUrl: z.string().url({ message: "Invalid URL format" }).optional().nullable().default(null),
+  tools: z.array(z.string()).default([]),
 });
 
 export type LLMAgent = z.infer<typeof LLMAgentSchema>;
@@ -136,6 +137,7 @@ export function createDefaultAgent<T extends Agent['type']>(
         instruction: '',
         systemPrompt: '',
         avatarUrl: null,
+        tools: [],
       } as any;
       
     case 'sequential':


### PR DESCRIPTION
## Summary
- add tool selection tab for agents
- support tools array in agent types and validation schema
- expose default export for `agentService`
- update AgentEditor to show new tools tab
- update snapshot and add AgentToolsTab tests

## Testing
- `npm run lint` *(fails: 769 errors, 187 warnings)*
- `npm run test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848e2a20924832eab92f310122850f1