### PR TITLE
Fix some lint warnings in type definitions

### DIFF
--- a/client/src/types/agents.ts
+++ b/client/src/types/agents.ts
@@ -147,6 +147,4 @@ export type AgentUpdateDTO = z.infer<typeof AgentUpdateDTOSchema>;
 /**
  * Interface para os dados resumidos de um agente a serem exibidos no AgentCard.
  */
-export interface AgentCardData extends AgentSummaryDTO {
-  // Adicionar quaisquer propriedades específicas da UI aqui, se necessário
-}
+export type AgentCardData = AgentSummaryDTO

--- a/client/src/types/auditLog.ts
+++ b/client/src/types/auditLog.ts
@@ -7,6 +7,6 @@ export interface AuditLog {
     name: string
   }
   action: string
-  details: Record<string, any>
+  details: Record<string, unknown>
   ipAddress?: string
 }

--- a/client/src/types/chatTypes.ts
+++ b/client/src/types/chatTypes.ts
@@ -10,7 +10,7 @@ export enum ChatMessageSenderType {
 export interface ChatMessageCreatePayload {
   content: string;
   sender_type: ChatMessageSenderType; // Should be 'USER' when client sends via postMessageToAgent
-  content_metadata?: Record<string, any> | null;
+  content_metadata?: Record<string, unknown> | null;
   parent_message_id?: string | null; // UUID
 }
 
@@ -20,7 +20,7 @@ export interface ChatMessage {
   session_id: string; // UUID
   sender_type: ChatMessageSenderType;
   content: string;
-  content_metadata?: Record<string, any> | null;
+  content_metadata?: Record<string, unknown> | null;
   parent_message_id?: string | null; // UUID
   created_at: string; // ISO datetime string
   updated_at: string; // ISO datetime string
@@ -31,13 +31,13 @@ export interface ChatMessage {
 export interface ChatSessionCreatePayload {
   agent_id: string; // UUID
   session_title?: string | null;
-  session_metadata?: Record<string, any> | null;
+  session_metadata?: Record<string, unknown> | null;
 }
 
 // Corresponds to ChatSessionUpdate in Pydantic
 export interface ChatSessionUpdatePayload {
   session_title?: string | null;
-  session_metadata?: Record<string, any> | null;
+  session_metadata?: Record<string, unknown> | null;
   // archived?: boolean | null; // If we add this field later
 }
 
@@ -47,7 +47,7 @@ export interface ChatSession {
   user_id: string; // UUID
   agent_id: string; // UUID
   session_title?: string | null;
-  session_metadata?: Record<string, any> | null;
+  session_metadata?: Record<string, unknown> | null;
   created_at: string; // ISO datetime string
   updated_at: string; // ISO datetime string
   // archived?: boolean; // If we add this field later
@@ -62,6 +62,6 @@ export interface ChatSessionDetail extends ChatSession {
 // if it's slightly different (e.g., sender_type is fixed to USER)
 export interface UserAgentMessagePayload {
     content: string;
-    content_metadata?: Record<string, any> | null;
+  content_metadata?: Record<string, unknown> | null;
     // sender_type is implicitly 'USER'
 }

--- a/client/src/types/core/agent.ts
+++ b/client/src/types/core/agent.ts
@@ -46,7 +46,7 @@ export interface SecurityScheme {
   in: 'header' | 'query' | 'cookie'
   scheme?: string
   bearerFormat?: string
-  flows?: any // OAuth2 flows
+  flows?: unknown // OAuth2 flows
 }
 
 /**
@@ -114,8 +114,8 @@ export interface LlmAgentConfig extends AgentConfig {
   includeContents?: 'default' | 'none' // How to include context
 
   // Advanced
-  planner?: any // Planner configuration
-  codeExecutor?: any // Code executor configuration
+  planner?: unknown // Planner configuration
+  codeExecutor?: unknown // Code executor configuration
 }
 
 /**

--- a/client/src/types/core/tool.ts
+++ b/client/src/types/core/tool.ts
@@ -22,8 +22,8 @@ export interface ToolParameter {
     | 'null'
   description?: string
   required?: boolean
-  default?: any
-  enum?: any[]
+  default?: unknown
+  enum?: unknown[]
   items?: ToolParameter
   properties?: Record<string, ToolParameter>
 }
@@ -40,7 +40,7 @@ export interface Tool {
   required?: string[]
   schema?: {
     type: string
-    properties: Record<string, any>
+    properties: Record<string, unknown>
     required?: string[]
   }
 }
@@ -59,7 +59,7 @@ export interface ToolCall {
 
 export type ToolResult = {
   toolCallId: string
-  output: any
+  output: unknown
   error?: string
 }
 
@@ -85,7 +85,7 @@ export interface ToolExecutionContext {
   /**
    * Additional metadata
    */
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 }
 
 /**
@@ -95,13 +95,13 @@ export type ToolHandler = (
   /**
    * The parameters for the tool
    */
-  params: Record<string, any>,
+  params: Record<string, unknown>,
 
   /**
    * The execution context
    */
   context: ToolExecutionContext,
-) => Promise<any>
+) => Promise<unknown>
 
 /**
  * Tool definition with handler

--- a/client/src/types/custom.d.ts
+++ b/client/src/types/custom.d.ts
@@ -1,6 +1,6 @@
 // Definições de tipos para módulos personalizados
 declare module '*.svg' {
-  import React = require('react')
+  import * as React from 'react'
   export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>
   const src: string
   export default src

--- a/client/src/types/governance.ts
+++ b/client/src/types/governance.ts
@@ -36,7 +36,7 @@ export interface AuditLog {
   timestamp: string
   actor: AuditLogActor
   action: string
-  details: Record<string, any>
+  details: Record<string, unknown>
   ipAddress?: string
 }
 

--- a/client/src/types/qa.ts
+++ b/client/src/types/qa.ts
@@ -18,7 +18,7 @@ export enum TestCaseStatus {
 export interface TestCase {
   id: string
   description: string
-  input: Record<string, any> // Entrada fornecida ao agente
+  input: Record<string, unknown> // Entrada fornecida ao agente
   expectedOutput: string // Saída esperada
   actualOutput: string // Saída real do agente
   status: TestCaseStatus

--- a/client/src/types/tools/tool.types.ts
+++ b/client/src/types/tools/tool.types.ts
@@ -9,7 +9,7 @@ export interface ToolParameterDTO {
   type: string; // ex: 'string', 'number', 'boolean'
   required: boolean;
   options?: string[]; // Para tipos enum ou select
-  default_value?: any;
+  default_value?: unknown;
 }
 
 /**

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -26,15 +26,9 @@ declare module '@/types/agents' {
 
 declare module '@/types/dashboard' {
   export type AgentStatus = 'online'|'offline'|'pending'|'error';
-  export interface Activity {
-    // Activity properties
-  }
-  export interface AgentActivityData {
-    // Agent activity data properties
-  }
-  export interface DashboardStats {
-    // Dashboard stats properties
-  }
+  export type Activity = Record<string, unknown>
+  export type AgentActivityData = Record<string, unknown>
+  export type DashboardStats = Record<string, unknown>
 }
 
 declare module '@/api/agentService' {
@@ -70,17 +64,13 @@ declare module '@/api/toolService' {
   export type ToolType = 'function'|'api'|'plugin';
   
   export interface ToolDTO extends Tool {
-    parameters?: Record<string, any>;
+    parameters?: Record<string, unknown>;
     // Additional DTO properties
   }
   
-  export interface CreateToolDTO {
-    // Create tool properties
-  }
+  export type CreateToolDTO = Record<string, unknown>
   
-  export interface UpdateToolDTO {
-    // Update tool properties
-  }
+  export type UpdateToolDTO = Record<string, unknown>
   
   export function createTool(tool: CreateToolDTO): Promise<ToolDTO>;
   export function updateTool(id: string, tool: UpdateToolDTO): Promise<ToolDTO>;


### PR DESCRIPTION
## Summary
- clean up type definitions for lint compliance
- update various types to avoid `any`

## Testing
- `npx eslint . --ext ts,tsx`
- `npm --prefix client test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_684ccc1c07a8832e93fef27d1b554ad8