### PR TITLE
Fix undefined arrays causing length errors

### DIFF
--- a/client/src/components/agents/forms/AgentMemoryTab.tsx
+++ b/client/src/components/agents/forms/AgentMemoryTab.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import type { KnowledgeBaseDTO } from '../../../api/memoryService'; // Assumindo que este tipo existe
-import memoryService from '../../../api/memoryService'; // Assumindo que este serviço existe
+import type { KnowledgeBaseDTO } from '../../../api/memoryService';
+import { memoryService } from '../../../api/memoryService';
 import {
   Card,
   CardContent,

--- a/client/src/components/agents/forms/AgentToolsTab.tsx
+++ b/client/src/components/agents/forms/AgentToolsTab.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from '../../ui/checkbox';
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
-import { toast } from '../../ui/use-toast';
+import { useToast } from '../../ui/use-toast';
 import { ToolDefinitionForm } from './ToolDefinitionForm';
 
 const transformToUiDefinition = (toolDto: ToolDTO): UiToolDefinition => {
@@ -47,6 +47,7 @@ interface AgentToolsTabProps {
 
 export function AgentToolsTab({ agentId }: AgentToolsTabProps) {
   const form = useFormContext<LlmAgentConfig>();
+  const { toast } = useToast();
   const [searchTerm, setSearchTerm] = useState('');
   const [configuredToolsDetails, setConfiguredToolsDetails] = useState<Record<string, UiToolDefinition>>({});
   const [selectedToolForConfiguration, setSelectedToolForConfiguration] = useState<UiToolDefinition | null>(null);

--- a/client/src/hooks/useDashboardMetrics.ts
+++ b/client/src/hooks/useDashboardMetrics.ts
@@ -3,8 +3,8 @@ import { useMemo } from 'react'
 import { Agent, DashboardStats,TokenUsageData } from '@/types/dashboard'
 
 export const useDashboardMetrics = (
-  agents: Agent[],
-  tokenUsage: TokenUsageData[],
+  agents: Agent[] = [],
+  tokenUsage: TokenUsageData[] = [],
 ) => {
   // Calculate token metrics
   const tokenMetrics = useMemo(() => {


### PR DESCRIPTION
## Summary
- default array args for dashboard metrics hook
- update memory tab to use named memoryService export
- fix toast usage in agent tools tab

## Testing
- `npm run lint` *(fails: 230 errors)*
- `npm test` *(fails: missing jsdom and 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cd75eda28832ebe33e1a2f145f145