### PR TITLE
Reduce ESLint violations

### DIFF
--- a/client/src/components/agents/AgentEditor.test.tsx
+++ b/client/src/components/agents/AgentEditor.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/components/ui/use-toast', () => ({
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal()
   return {
-    // @ts-ignore
+    // @ts-expect-error -- useNavigate's actual type isn't needed for this mock
     ...actual, // import and retain default behavior
     useNavigate: () => vi.fn(),
     useParams: () => ({ id: undefined }), // Mock for 'create' mode

--- a/client/src/components/agents/AgentSubNav.test.tsx
+++ b/client/src/components/agents/AgentSubNav.test.tsx
@@ -33,7 +33,7 @@ const mockAgentNavigationItems = [
 
 describe('AgentSubNav', () => {
   const renderAgentSubNav = (currentPath: string) => {
-    (useLocation as any).mockReturnValue({ pathname: currentPath });
+    (useLocation as vi.Mock).mockReturnValue({ pathname: currentPath });
     return render(
       <MemoryRouter initialEntries={[currentPath]}>
         <AgentSubNav />

--- a/client/src/components/agents/forms/AgentToolsTab.stories.tsx
+++ b/client/src/components/agents/forms/AgentToolsTab.stories.tsx
@@ -2,6 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { http } from 'msw';
 import { FormProvider, useForm } from 'react-hook-form';
 
+interface StoryArgs {
+  defaultValues?: {
+    tools: string[];
+    detailedToolDefinitions?: unknown[];
+  };
+}
+
 import { ToolDTO } from '@/api/toolService';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -78,7 +85,7 @@ const meta: Meta<typeof AgentToolsTab> = {
     (Story, { args }) => {
       const formMethods = useForm({
         // Use defaultValues from the story's args, or a default state
-        defaultValues: (args as any).defaultValues || {
+        defaultValues: (args as StoryArgs).defaultValues || {
           tools: [],
           detailedToolDefinitions: [],
         },

--- a/client/src/components/agents/forms/AgentToolsTab.test.tsx
+++ b/client/src/components/agents/forms/AgentToolsTab.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach,describe, expect, it, vi } from 'vitest'
 
 import { ToolDTO } from '@/api/toolService'
 import { useToolStore } from '@/store/toolStore'
-import { LlmAgentConfig, LlmAgentConfigSchema, AgentType } from '@/types/agents'
+// Types are declared globally in vite-env.d.ts
 
 import AgentToolsTab from './AgentToolsTab'
 

--- a/client/src/components/agents/forms/AgentToolsTab.tsx
+++ b/client/src/components/agents/forms/AgentToolsTab.tsx
@@ -8,7 +8,7 @@ import { LlmAgentConfig, UiToolDefinition } from '../../../types/agents';
 import { Button } from '../../ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { Checkbox } from '../../ui/checkbox';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form';
+import { FormDescription, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { useToast } from '../../ui/use-toast';
@@ -41,11 +41,7 @@ const transformToUiDefinition = (toolDto: ToolDTO): UiToolDefinition => {
   };
 };
 
-interface AgentToolsTabProps {
-  agentId?: string;
-}
-
-export function AgentToolsTab({ agentId }: AgentToolsTabProps) {
+export function AgentToolsTab() {
   const form = useFormContext<LlmAgentConfig>();
   const { toast } = useToast();
   const [searchTerm, setSearchTerm] = useState('');

--- a/client/src/components/agents/forms/BaseAgentForm.stories.tsx
+++ b/client/src/components/agents/forms/BaseAgentForm.stories.tsx
@@ -13,8 +13,6 @@ const DemoSchema = z.object({
   email: z.string().email({ message: 'Please enter a valid email.' }),
 });
 
-type DemoFormValues = z.infer<typeof DemoSchema>;
-
 const meta: Meta<typeof BaseAgentForm> = {
   title: 'Agents/Forms/BaseAgentForm',
   component: BaseAgentForm,

--- a/client/src/components/agents/forms/BaseAgentForm.tsx
+++ b/client/src/components/agents/forms/BaseAgentForm.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { FormProvider,useForm } from 'react-hook-form'
 import { z } from 'zod'
 
-import { AnyAgentConfig as BaseAgent, LlmAgentConfigSchema as BaseAgentSchema } from '../../../types/agents'
+
 import { Button } from '../../ui/button'
 import { Form } from '../../ui/form'
 
@@ -29,7 +29,7 @@ export function BaseAgentForm<T extends z.ZodType>({
 }: BaseAgentFormProps<T>) {
   const form = useForm<z.infer<T>>({
     resolver: zodResolver(schema),
-    defaultValues: defaultValues as any,
+    defaultValues: defaultValues as z.infer<T>,
   })
 
   return (

--- a/client/src/components/agents/forms/LLMAgentForm.tsx
+++ b/client/src/components/agents/forms/LLMAgentForm.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -24,7 +24,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -35,12 +34,7 @@ import {
 import { Slider } from '@/components/ui/slider';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+// Tooltip components are not currently used
 import { cn } from '@/lib/utils';
 import { LLMAgent } from '@/types/agents';
 

--- a/client/src/components/agents/forms/ToolDefinitionForm.tsx
+++ b/client/src/components/agents/forms/ToolDefinitionForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PlusCircle, Trash2 } from 'lucide-react';
 import React, { useEffect } from 'react';
-import { Controller, SubmitHandler,useFieldArray, useForm } from 'react-hook-form';
+import { SubmitHandler, useFieldArray, useForm } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';
 import * as z from 'zod';
 
@@ -145,7 +145,7 @@ export const ToolDefinitionForm: React.FC<ToolDefinitionFormProps> = ({ initialD
           if (param.paramType === 'NUMBER') adkDefaultValue = parseFloat(param.paramDefaultValue);
           else if (param.paramType === 'BOOLEAN') adkDefaultValue = param.paramDefaultValue.toLowerCase() === 'true';
           else if (param.paramType === 'OBJECT' || param.paramType === 'ARRAY') {
-            try { adkDefaultValue = JSON.parse(param.paramDefaultValue); } catch (e) { /* keep as string if parse fails */ }
+            try { adkDefaultValue = JSON.parse(param.paramDefaultValue); } catch { /* keep as string if parse fails */ }
           }
         }
 
@@ -155,7 +155,7 @@ export const ToolDefinitionForm: React.FC<ToolDefinitionFormProps> = ({ initialD
             if (param.paramType === 'NUMBER') return parseFloat(enumStr);
             if (param.paramType === 'BOOLEAN') return enumStr.toLowerCase() === 'true';
             if (param.paramType === 'OBJECT' || param.paramType === 'ARRAY') {
-              try { return JSON.parse(enumStr); } catch (e) { return enumStr; }
+              try { return JSON.parse(enumStr); } catch { return enumStr; }
             }
             return enumStr;
           });
@@ -189,7 +189,7 @@ export const ToolDefinitionForm: React.FC<ToolDefinitionFormProps> = ({ initialD
         <CardTitle>Configurar Ferramenta: {methods.watch('name') || initialData?.name || 'Nova Ferramenta'}</CardTitle>
         <CardDescription>
           Defina nome, descrição e parâmetros para esta ferramenta, seguindo as especificações do Google ADK.
-          A função 'execute' será definida no backend.
+          A função &quot;execute&quot; será definida no backend.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -345,7 +345,7 @@ export const ToolDefinitionForm: React.FC<ToolDefinitionFormProps> = ({ initialD
               </Button>
               {fields.length === 0 && (
                 <p className="text-sm text-muted-foreground text-center py-4">
-                  Nenhum parâmetro definido. Clique em "Adicionar Parâmetro" para começar.
+                  Nenhum parâmetro definido. Clique em &quot;Adicionar Parâmetro&quot; para começar.
                 </p>
               )}
             </div>

--- a/client/src/components/chat/Message.tsx
+++ b/client/src/components/chat/Message.tsx
@@ -46,10 +46,10 @@ const Message: React.FC<MessageProps> = ({
                 <Zap className="mr-2 h-3 w-3 text-yellow-500" />
                 Iniciando a tarefa: Análise de Mercado
               </p>
-              <p className="text-xs flex items-center">
-                <Wrench className="mr-2 h-3 w-3 text-blue-500" />
-                Usando ferramenta: 'Web Search'
-              </p>
+                <p className="text-xs flex items-center">
+                  <Wrench className="mr-2 h-3 w-3 text-blue-500" />
+                  Usando ferramenta: &quot;Web Search&quot;
+                </p>
               <p className="text-xs flex items-center">
                 <Check className="mr-2 h-3 w-3 text-green-500" />
                 Ferramenta executada com sucesso.

--- a/client/src/components/ui/Dialog.stories.tsx
+++ b/client/src/components/ui/Dialog.stories.tsx
@@ -79,7 +79,7 @@ export const FormDialog: Story = {
         <DialogHeader>
           <DialogTitle>Edit profile</DialogTitle>
           <DialogDescription>
-            Make changes to your profile here. Click save when you're done.
+            Make changes to your profile here. Click save when you&apos;re done.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">

--- a/client/src/components/ui/StatusBadge.tsx
+++ b/client/src/components/ui/StatusBadge.tsx
@@ -10,7 +10,7 @@ import {
   Rocket,
 } from 'lucide-react'
 
-import { Badge, type BadgeProps } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 
 import {

--- a/client/src/components/ui/accordion.stories.tsx
+++ b/client/src/components/ui/accordion.stories.tsx
@@ -107,3 +107,7 @@ export const Multiple: Story = {
           <AccordionTrigger>{item.question}</AccordionTrigger>
           <AccordionContent>{item.answer}</AccordionContent>
         </AccordionItem>
+      ))}
+    </Accordion>
+  ),
+};

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -34,8 +34,9 @@ const DialogPortal: React.FC<DialogPortalProps> = ({
 DialogPortal.displayName = 'DialogPortal'
 
 // Dialog Overlay Props
-interface DialogOverlayProps
-  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> {}
+type DialogOverlayProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Overlay
+>;
 
 // Dialog Overlay
 const DialogOverlay = React.forwardRef<
@@ -57,8 +58,9 @@ const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = 'DialogOverlay'
 
 // Dialog Content
-interface DialogContentProps
-  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {}
+type DialogContentProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+>;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -92,7 +94,7 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = 'DialogContent'
 
 // Dialog Header
-interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+type DialogHeaderProps = React.HTMLAttributes<HTMLDivElement>;
 
 const DialogHeader: React.FC<DialogHeaderProps> = ({ className, ...props }) => (
   <div
@@ -107,7 +109,7 @@ const DialogHeader: React.FC<DialogHeaderProps> = ({ className, ...props }) => (
 DialogHeader.displayName = 'DialogHeader'
 
 // Dialog Footer
-interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+type DialogFooterProps = React.HTMLAttributes<HTMLDivElement>;
 
 const DialogFooter: React.FC<DialogFooterProps> = ({ className, ...props }) => (
   <div
@@ -122,8 +124,9 @@ const DialogFooter: React.FC<DialogFooterProps> = ({ className, ...props }) => (
 DialogFooter.displayName = 'DialogFooter'
 
 // Dialog Title
-interface DialogTitleProps
-  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> {}
+type DialogTitleProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Title
+>;
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -142,8 +145,9 @@ const DialogTitle = React.forwardRef<
 DialogTitle.displayName = 'DialogTitle'
 
 // Dialog Description
-interface DialogDescriptionProps
-  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> {}
+type DialogDescriptionProps = React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Description
+>;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/client/src/components/ui/scroll-area.stories.tsx
+++ b/client/src/components/ui/scroll-area.stories.tsx
@@ -77,7 +77,7 @@ export const HorizontalScrolling: Story = {
             <div className="overflow-hidden rounded-md">
               <img
                 src={artwork.art}
-                alt={`Photo by ${artwork.artist}`}
+                alt={artwork.artist}
                 className="aspect-[3/4] h-fit w-fit object-cover"
                 width={300}
                 height={400}

--- a/client/src/components/ui/skeleton.tsx
+++ b/client/src/components/ui/skeleton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
 
 const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
   ({ className, ...props }, ref) => {

--- a/client/src/components/ui/tag-input.tsx
+++ b/client/src/components/ui/tag-input.tsx
@@ -1,4 +1,4 @@
-import { Plus,X } from 'lucide-react'
+import { X } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from '@/lib/utils'
@@ -97,7 +97,7 @@ export function TagInput({
     inputClassName,
   )
 
-  const tagClasses = (index: number) =>
+  const tagClasses = () =>
     cn(
       'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium',
       'bg-primary/10 text-primary',
@@ -110,13 +110,23 @@ export function TagInput({
     <div
       className={containerClasses}
       onClick={() => !disabled && inputRef.current?.focus()}
+      onKeyDown={(e) => {
+        if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+          inputRef.current?.focus();
+        }
+      }}
+      role="button"
+      tabIndex={0}
       {...props}
     >
       {tags.map((tag, index) => (
         <div
           key={`${tag}-${index}`}
-          className={tagClasses(index)}
+          className={tagClasses()}
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          role="button"
+          tabIndex={0}
         >
           <span>{tag}</span>
           {!disabled && (

--- a/client/src/components/ui/textarea.tsx
+++ b/client/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/client/src/hooks/useDashboardData.test.ts
+++ b/client/src/hooks/useDashboardData.test.ts
@@ -22,7 +22,7 @@ describe('useDashboardData', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ;(useDashboardStore as unknown as vi.Mock).mockImplementation(
-      (selector: any) => selector(storeState),
+      (selector: (state: typeof storeState) => unknown) => selector(storeState),
     )
   })
 

--- a/client/src/hooks/useTheme.ts
+++ b/client/src/hooks/useTheme.ts
@@ -1,4 +1,3 @@
-import { useContext } from 'react'
 
 import { theme } from '@/theme'
 
@@ -17,13 +16,13 @@ export const useTheme = (): Theme => {
  * @param path Dot notation path to the theme value (e.g., 'colors.primary')
  * @returns The theme value or undefined if not found
  */
-export const useThemeValue = <T = any>(path: string): T | undefined => {
-  const theme = useTheme()
+export const useThemeValue = <T = unknown>(path: string): T | undefined => {
+  const themeObj = useTheme()
 
   // Split the path into parts and traverse the theme object
-  return path.split('.').reduce((obj, key) => {
-    return obj && obj[key as keyof typeof obj]
-  }, theme as any) as T
+  return path.split('.').reduce((obj: unknown, key) => {
+    return obj && (obj as Record<string, unknown>)[key]
+  }, themeObj as Record<string, unknown>) as T
 }
 
 export default useTheme

--- a/client/src/lib/agent-utils.ts
+++ b/client/src/lib/agent-utils.ts
@@ -71,22 +71,24 @@ export function validateAgent(agent: Agent): {
 
   // Type-specific validations
   switch (agent.type) {
-    case 'llm':
+    case 'llm': {
       const llmAgent = agent as LLMAgent
       if (!llmAgent.instruction?.trim()) {
         errors.push('Instructions are required for LLM agents')
       }
       break
+    }
 
     case 'sequential':
-    case 'parallel':
+    case 'parallel': {
       const workflowAgent = agent as SequentialAgent | ParallelAgent
       if (!workflowAgent.agents?.length) {
         errors.push('Workflow must contain at least one agent')
       }
       break
+    }
 
-    case 'a2a':
+    case 'a2a': {
       const a2aAgent = agent as A2AAgent
       try {
         new URL(a2aAgent.endpoint)
@@ -94,6 +96,7 @@ export function validateAgent(agent: Agent): {
         errors.push('A valid endpoint URL is required for A2A agents')
       }
       break
+    }
   }
 
   return {
@@ -105,8 +108,10 @@ export function validateAgent(agent: Agent): {
 /**
  * Get the default configuration for a tool based on its schema
  */
-export function getDefaultToolConfig(parameters: any[]): Record<string, any> {
-  const config: Record<string, any> = {}
+export function getDefaultToolConfig(
+  parameters: Array<{ name: string; type: string; default?: unknown; required?: boolean }>
+): Record<string, unknown> {
+  const config: Record<string, unknown> = {}
 
   parameters.forEach((param) => {
     if (param.default !== undefined) {
@@ -140,7 +145,7 @@ export function getDefaultToolConfig(parameters: any[]): Record<string, any> {
  * Format an agent's configuration for display
  */
 export function formatAgentConfig(agent: Agent): string {
-  const config: Record<string, any> = { ...agent }
+  const config: Record<string, unknown> = { ...agent }
 
   // Remove internal fields
   const internalFields = ['id', 'createdAt', 'updatedAt', 'version']


### PR DESCRIPTION
## Summary
- replace `@ts-ignore` with `@ts-expect-error`
- tighten mocked `useLocation` type
- introduce `StoryArgs` typing for tools stories
- clean up unused types and imports
- fix accessibility and quote issues
- prefer type aliases for empty interfaces
- wrap switch cases to satisfy no-case-declarations
- improve generic typings

## Testing
- `npm run lint --debug` *(fails: 169 problems remain)*

------
https://chatgpt.com/codex/tasks/task_e_684d690f7184832e8c0e8717b3acd09a